### PR TITLE
Set the `alertSeverity` value

### DIFF
--- a/helm_deploy/manage-recalls-api/values.yaml
+++ b/helm_deploy/manage-recalls-api/values.yaml
@@ -41,3 +41,4 @@ generic-service:
 
 generic-prometheus-alerts:
   targetApplication: manage-recalls-api
+  alertSeverity: ppud-replacement-alerts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,6 +6,3 @@ generic-service:
 
   ingress:
     host: manage-recalls-api-dev.hmpps.service.justice.gov.uk
-
-generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
This was given to us from the cloud platform team to be used so that
alerts are routed to us correctly...

ref:
- ministryofjustice/cloud-platform#2926 (comment)
- https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#create-a-prometheusrule