### PR TITLE
PUD-107: Add gotenburg as a helm subchart

### DIFF
--- a/helm_deploy/manage-recalls-api/Chart.yaml
+++ b/helm_deploy/manage-recalls-api/Chart.yaml
@@ -5,6 +5,9 @@ name: manage-recalls-api
 version: 0.2.0
 
 dependencies:
+  - name: gotenberg
+    version: 0.1.0
+    repository: file://subcharts/gotenberg
   - name: generic-service
     version: 1.0.9
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/manage-recalls-api/subcharts/gotenberg/.helmignore
+++ b/helm_deploy/manage-recalls-api/subcharts/gotenberg/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm_deploy/manage-recalls-api/subcharts/gotenberg/Chart.yaml
+++ b/helm_deploy/manage-recalls-api/subcharts/gotenberg/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: "6.3.0"
+description: A Helm chart for Gotenberg
+name: gotenberg
+version: 0.1.0
+

--- a/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/_helpers.tpl
+++ b/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a string from a list of values joined by a comma
+*/}}
+{{- define "app.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "app.labels" -}}
+helm.sh/chart: {{ include "app.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "app.selectorLabels" -}}
+app: {{ include "app.name" . }}
+release: {{ .Release.Name }}
+{{- end }}

--- a/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/deployment.yaml
+++ b/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 50%
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - {{ template "app.name" . }}
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.image.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.image.port }}
+            periodSeconds: 30
+            initialDelaySeconds: 90
+            timeoutSeconds: 20
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.image.port }}
+            periodSeconds: 20
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 15

--- a/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/service.yaml
+++ b/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "app.fullname" . }}
+  labels:
+  {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: {{ .Values.image.port }}
+      name: http
+  selector:
+  {{- include "app.selectorLabels" . | nindent 4 }}

--- a/helm_deploy/manage-recalls-api/subcharts/gotenberg/values.yaml
+++ b/helm_deploy/manage-recalls-api/subcharts/gotenberg/values.yaml
@@ -1,0 +1,9 @@
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# These 'default' values can be overriden by the parent chart: https://helm.sh/docs/chart_template_guide/subcharts_and_globals/
+replicaCount: 2
+
+image:
+  repository: thecodingmachine/gotenberg
+  tag: 6.4.4
+  port: 3000


### PR DESCRIPTION
This installs gotenburg as a separate deployment/service within k8s 
so it  can be used by the API service (rather than a sidecar), but it will 
be deployed as part of the API service helm chart.

Gotenburg will be available internally (within the k8s namespace) at the following URL:

http://manage-recalls-api-gotenburg

(No need for a port as the service is listening on port 80).