### PR TITLE
PUD-208: Ignore trivy warning whilst DPS_tech_team find a fix for security issues with spring 5.5.1

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+#Ignore due to dps_tech_team security issues with upgrades (5/7/21)
+# https://mojdt.slack.com/archives/CK0QLCQ1G/p1625473241438200
+CVE-2021-22119

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.3"
   kotlin("plugin.spring") version "1.5.10"
   kotlin("plugin.jpa") version "1.5.20"
 }


### PR DESCRIPTION

- uplift to latest hmpps.gradle-spring-boot plugin