### PR TITLE
PUD-276: Add specific handling of tiny types in SpringFoxConfig.  (Te…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/SpringFoxConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/SpringFoxConfig.kt
@@ -7,6 +7,9 @@ import springfox.documentation.builders.RequestHandlerSelectors
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spring.web.plugins.Docket
 import springfox.documentation.swagger2.annotations.EnableSwagger2
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import java.util.UUID
 
 @Configuration
 @EnableSwagger2
@@ -19,5 +22,7 @@ class SpringFoxConfig {
       .apis(RequestHandlerSelectors.any())
       .paths(PathSelectors.any())
       .build()
+      .directModelSubstitute(NomsNumber::class.java, String::class.java)
+      .directModelSubstitute(RecallId::class.java, UUID::class.java)
   }
 }


### PR DESCRIPTION
…mporary until I figure out why it isn't using the correct ObjectMapper to generate the swagger definitions)