### PR TITLE
PUD-329: Bug: persistence as ENUM not working versus actual Postgres DB but passes build test

### DIFF
--- a/src/main/resources/db/migration/V6__Make_document_category_varchar_not_enum.sql
+++ b/src/main/resources/db/migration/V6__Make_document_category_varchar_not_enum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE recall_document ALTER COLUMN category SET DATA TYPE varchar(32);


### PR DESCRIPTION
PUD-329: Change SQL type of category column.  Only tested/testable by local running of actual app.  (Also, leaves the SQL ENUM type recall_document_category in existence but un-used).