### PR TITLE
PUD-426 Upgrade HMPPS Spring-boot gradle plugin to 3.3.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.6"
   kotlin("plugin.spring") version "1.5.10"
   kotlin("plugin.jpa") version "1.5.20"
 }


### PR DESCRIPTION
In order to ensure that spring-security-core is on v5.5.1 (which contains the vulnerability fix reported by the security pipeline)
