### PR TITLE
Disable sentry in local development

### DIFF
--- a/helm_deploy/manage-recalls-api/values.yaml
+++ b/helm_deploy/manage-recalls-api/values.yaml
@@ -25,6 +25,7 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     GOTENBERG_ENDPOINT_URL: http://manage-recalls-api-gotenberg
+    SENTRY_DSN: https://ea6c4e03abe840319aee1bc1b2a6a58a@o345774.ingest.sentry.io/5940644
 
   namespace_secrets:
     manage-recalls-api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,10 +80,6 @@ management:
       cache:
         time-to-live: 2000ms
 
-sentry:
-  dsn: https://ea6c4e03abe840319aee1bc1b2a6a58a@o345774.ingest.sentry.io/5940644
-  environment: ${SENTRY_ENVIRONMENT:LOCAL}
-
 prisonerSearch:
   endpoint:
     url: http://localhost:9092


### PR DESCRIPTION
This removes the DSN configuration in local development so we don't spam
sentry with errors.