### PR TITLE
Add in the needed ingress annotations for cluster migration.

### DIFF
--- a/helm_deploy/manage-recalls-api/Chart.yaml
+++ b/helm_deploy/manage-recalls-api/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.1.0
     repository: file://subcharts/gotenberg
   - name: generic-service
-    version: 1.0.12
+    version: 1.0.16
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 0.2.5

--- a/helm_deploy/manage-recalls-api/values.yaml
+++ b/helm_deploy/manage-recalls-api/values.yaml
@@ -13,7 +13,6 @@ generic-service:
     enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: manage-recalls-api-cert
-    path: /
 
   env:
     JAVA_OPTS: "-Xmx512m"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,8 @@ generic-service:
   ingress:
     host: manage-recalls-api-dev.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-dev-cert
+    # which cluster are we on: live-1 is blue, live is green
+    contextColour: blue
 
   env:
     OAUTH_ENDPOINT_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,6 +7,8 @@ generic-service:
   ingress:
     host: manage-recalls-api-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-preprod-cert
+    # which cluster are we on: live-1 is blue, live is green
+    contextColour: blue
 
   env:
     OAUTH_ENDPOINT_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,6 +7,8 @@ generic-service:
   ingress:
     host: manage-recalls-api.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-prod-cert
+    # which cluster are we on: live-1 is blue, live is green
+    contextColour: blue
 
   env:
     OAUTH_ENDPOINT_URL: https://sign-in.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
ref: https://mojdt.slack.com/archives/CH6D099DF/p1633679858013800

This bump in the `generic-service` template adds in the needed
annotations requested by the cloud platform team. When the time comes to
move our apps onto the new "live" cluster the `contextColor` directive
will allow us to switch traffic (but it doesn't impact deployment,
that's another story).