### PR TITLE
Tell Trivy to use the "light" database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,11 +192,13 @@ workflows:
           name: trivy_scan_low_medium_cves
           fail_build: false
           cve_severities_to_check: UNKNOWN,LOW,MEDIUM
+          additional_args: --light
           requires:
             - build_docker
 
       - hmpps/trivy_pipeline_scan:
           name: trivy_scan
+          additional_args: --light
           requires:
             - build_docker
 


### PR DESCRIPTION
Before I go full on self-hosting the Trivy database, try to see if the
"light" variant is more reliable (as it's a lot smaller to download).

ref: https://aquasecurity.github.io/trivy/v0.20.0/vulnerability/examples/db/#lightweight-db