### PR TITLE
PUD-906: Add createdByUserId to Recall

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallsController.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.CourtValidationService
-import uk.gov.justice.digital.hmpps.managerecallsapi.service.DocumentService
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.PrisonValidationService
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.RecallService
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.UserDetailsService
@@ -43,7 +42,6 @@ import java.time.OffsetDateTime
 class RecallsController(
   @Autowired private val recallRepository: RecallRepository,
   @Autowired private val recallNotificationService: RecallNotificationService,
-  @Autowired private val documentService: DocumentService,
   @Autowired private val dossierService: DossierService,
   @Autowired private val letterToPrison: LetterToPrisonService,
   @Autowired private val userDetailsService: UserDetailsService,
@@ -124,6 +122,7 @@ class RecallsController(
   fun Recall.toResponse() = RecallResponse(
     recallId = this.recallId(),
     nomsNumber = this.nomsNumber,
+    createdByUserId = this.createdByUserId(),
     createdDateTime = this.createdDateTime,
     lastUpdatedDateTime = this.lastUpdatedDateTime,
     documents = documents.map { doc -> ApiRecallDocument(doc.id(), doc.category, doc.fileName) },
@@ -182,14 +181,15 @@ class RecallsController(
 
 fun BookRecallRequest.toRecall(): Recall {
   val now = OffsetDateTime.now()
-  return Recall(::RecallId.random(), this.nomsNumber, now, now)
+  return Recall(::RecallId.random(), this.nomsNumber, this.createdByUserId, now, now)
 }
 
-data class BookRecallRequest(val nomsNumber: NomsNumber)
+data class BookRecallRequest(val nomsNumber: NomsNumber, val createdByUserId: UserId)
 
 data class RecallResponse(
   val recallId: RecallId,
   val nomsNumber: NomsNumber,
+  val createdByUserId: UserId,
   val createdDateTime: OffsetDateTime,
   val lastUpdatedDateTime: OffsetDateTime,
   val documents: List<ApiRecallDocument> = emptyList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Recall.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Recall.kt
@@ -38,6 +38,8 @@ data class Recall(
   @Convert(converter = NomsNumberJpaConverter::class)
   val nomsNumber: NomsNumber,
   @Column(nullable = false)
+  val createdByUserId: UUID,
+  @Column(nullable = false)
   val createdDateTime: OffsetDateTime,
   @Column(nullable = false)
   val lastUpdatedDateTime: OffsetDateTime,
@@ -93,6 +95,7 @@ data class Recall(
   constructor(
     recallId: RecallId,
     nomsNumber: NomsNumber,
+    createdByUserId: UserId,
     createdDateTime: OffsetDateTime,
     lastUpdatedDateTime: OffsetDateTime = createdDateTime,
     documents: Set<Document> = emptySet(),
@@ -134,6 +137,7 @@ data class Recall(
     this(
       recallId.value,
       nomsNumber,
+      createdByUserId.value,
       createdDateTime,
       lastUpdatedDateTime,
       documents,
@@ -174,6 +178,7 @@ data class Recall(
     )
 
   fun recallId() = RecallId(id)
+  fun createdByUserId() = createdByUserId.let(::UserId)
   fun assessedByUserId() = assessedByUserId?.let(::UserId)
   fun bookedByUserId() = bookedByUserId?.let(::UserId)
   fun dossierCreatedByUserId() = dossierCreatedByUserId?.let(::UserId)

--- a/src/main/resources/db/migration/V51__Add_created_by_user_id_to_recall.sql
+++ b/src/main/resources/db/migration/V51__Add_created_by_user_id_to_recall.sql
@@ -1,0 +1,1 @@
+ALTER TABLE recall ADD COLUMN created_by_user_id UUID not null default '00000000-0000-0000-0000-000000000000';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AssignRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AssignRecallComponentTest.kt
@@ -44,8 +44,9 @@ class AssignRecallComponentTest : ComponentTestBase() {
     val recallId = ::RecallId.random()
     val nomsNumber = NomsNumber("123456")
     val assignee = ::UserId.random()
+    val createdByUserId = ::UserId.random()
 
-    val recall = Recall(recallId, nomsNumber, now, now)
+    val recall = Recall(recallId, nomsNumber, createdByUserId, now, now)
     recallRepository.save(recall)
     userDetailsRepository.save(
       UserDetails(
@@ -67,6 +68,7 @@ class AssignRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           OffsetDateTime.now(fixedClock),
           assignee = assignee,
@@ -81,14 +83,15 @@ class AssignRecallComponentTest : ComponentTestBase() {
     val recallId = ::RecallId.random()
     val nomsNumber = NomsNumber("123456")
     val assignee = ::UserId.random()
+    val createdByUserId = ::UserId.random()
 
-    val recall = Recall(recallId, nomsNumber, now, now, assignee = assignee)
+    val recall = Recall(recallId, nomsNumber, createdByUserId, now, now, assignee = assignee)
     recallRepository.save(recall)
 
     val response = authenticatedClient.unassignRecall(recallId, assignee)
 
     assertThat(
-      response, equalTo(RecallResponse(recallId, nomsNumber, now, OffsetDateTime.now(fixedClock)))
+      response, equalTo(RecallResponse(recallId, nomsNumber, createdByUserId, now, OffsetDateTime.now(fixedClock)))
     )
   }
 
@@ -98,8 +101,9 @@ class AssignRecallComponentTest : ComponentTestBase() {
     val nomsNumber = NomsNumber("123456")
     val assignee = ::UserId.random()
     val otherAssignee = ::UserId.random()
+    val createdByUserId = ::UserId.random()
 
-    val recall = Recall(recallId, nomsNumber, OffsetDateTime.now(), assignee = assignee)
+    val recall = Recall(recallId, nomsNumber, createdByUserId, OffsetDateTime.now(), assignee = assignee)
     recallRepository.save(recall)
 
     authenticatedClient.unassignRecall(recallId, otherAssignee, HttpStatus.NOT_FOUND)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/BookRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/BookRecallComponentTest.kt
@@ -9,18 +9,22 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 
 class BookRecallComponentTest : ComponentTestBase() {
 
   @Test
   fun `book a recall creates a recall and returns recall details`() {
     val nomsNumber = NomsNumber("123456")
-    val response = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber))
+    val createdByUserId = ::UserId.random()
+    val response = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, createdByUserId))
 
     assertThat(
       response,
       allOf(
         has(RecallResponse::recallId, present()),
+        has(RecallResponse::createdByUserId, equalTo(createdByUserId)),
         has(RecallResponse::nomsNumber, equalTo(nomsNumber)),
         has(RecallResponse::createdDateTime, present()),
         has(RecallResponse::lastUpdatedDateTime, present()),
@@ -30,7 +34,13 @@ class BookRecallComponentTest : ComponentTestBase() {
 
   @Test
   fun `book a recall with blank nomsNumber returns 400`() {
-    authenticatedClient.post("/recalls", "{\"nomsNumber\":\"\"}")
+    authenticatedClient.post("/recalls", "{\"nomsNumber\":\"\", `\"createdByUserId\":\"${::UserId.random()}\"}")
+      .expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `book a recall without createdByUserId returns 400`() {
+    authenticatedClient.post("/recalls", "{\"nomsNumber\":\"123456\"}")
       .expectStatus().isBadRequest
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/CreateDossierComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/CreateDossierComponentTest.kt
@@ -17,6 +17,8 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.documents.readText
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.matchers.hasNumberOfPages
 import uk.gov.justice.digital.hmpps.managerecallsapi.search.Prisoner
 import uk.gov.justice.digital.hmpps.managerecallsapi.search.PrisonerSearchRequest
@@ -49,7 +51,7 @@ class CreateDossierComponentTest : ComponentTestBase() {
       // PS - not stubbing the reasonsForRecall since we now decorate this in the flow
     )
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber))
+    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, ::UserId.random()))
     authenticatedClient.updateRecall(
       recall.recallId,
       UpdateRecallRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
@@ -19,13 +19,13 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.documents.encodeToBase64Str
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 
 class DocumentComponentTest : ComponentTestBase() {
   private val nomsNumber = NomsNumber("123456")
-  private val bookRecallRequest = BookRecallRequest(nomsNumber)
+  private val bookRecallRequest = BookRecallRequest(nomsNumber, ::UserId.random())
   private val versionedDocumentCategory = PART_A_RECALL_REPORT
-  private val unVersionedDocumentCategory = UNCATEGORISED
   private val documentContents = "Expected Generated PDF".toByteArray()
   private val base64EncodedDocumentContents = documentContents.encodeToBase64String()
   private val fileName = "fileName"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
@@ -21,7 +21,7 @@ import java.util.stream.Stream
 class EndpointSecurityComponentTest : ComponentTestBase() {
 
   private val nomsNumber = NomsNumber("123456")
-  private val bookRecallRequest = BookRecallRequest(nomsNumber)
+  private val bookRecallRequest = BookRecallRequest(nomsNumber, ::UserId.random())
   private val fileBytes = "content".toByteArray()
   private val category = RecallDocumentCategory.PART_A_RECALL_REPORT
   private val addDocumentRequest = AddDocumentRequest(category, fileBytes.encodeToBase64String(), "part_a.pdf")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallComponentTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.fullyPopulatedRecall
 import java.time.Instant
@@ -29,12 +30,14 @@ class GetRecallComponentTest : ComponentTestBase() {
   @Test
   fun `get a recall that has just been booked`() {
     val recallId = ::RecallId.random()
+    val createdByUserId = ::UserId.random()
+
     val now = OffsetDateTime.ofInstant(Instant.parse("2021-10-04T14:15:43.682078Z"), ZoneId.of("UTC"))
-    recallRepository.save(Recall(recallId, nomsNumber, now, now))
+    recallRepository.save(Recall(recallId, nomsNumber, createdByUserId, now, now))
 
     val response = authenticatedClient.getRecall(recallId)
 
-    assertThat(response, equalTo(RecallResponse(recallId, nomsNumber, now, now)))
+    assertThat(response, equalTo(RecallResponse(recallId, nomsNumber, createdByUserId, now, now)))
   }
 
   @Test
@@ -43,7 +46,7 @@ class GetRecallComponentTest : ComponentTestBase() {
     val fullyPopulatedRecall = fullyPopulatedRecall(recallId)
     userDetailsRepository.save(
       UserDetails(
-        fullyPopulatedRecall.assignee()!!,
+        fullyPopulatedRecall.assignee!!,
         FirstName("Bertie"),
         LastName("Badger"),
         "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallNotificationComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallNotificationComponentTest.kt
@@ -31,7 +31,7 @@ class GetRecallNotificationComponentTest : ComponentTestBase() {
   @Test
   fun `get recall notification returns merged recall summary and revocation order`() {
     val userId = ::UserId.random()
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber))
+    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, ::UserId.random()))
     updateRecallWithRequiredInformationForTheRecallNotification(recall.recallId, userId)
 
     setupUserDetailsFor(userId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallsComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallsComponentTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -16,8 +17,9 @@ class GetRecallsComponentTest : ComponentTestBase() {
   @Test
   fun `get all recalls`() {
     val now = OffsetDateTime.ofInstant(Instant.parse("2021-10-04T14:15:43.682078Z"), ZoneId.of("UTC"))
-    val recall1 = Recall(::RecallId.random(), NomsNumber("123456"), now, now)
-    val recall2 = Recall(::RecallId.random(), NomsNumber("987654"), now, now)
+    val createdByUserId = ::UserId.random()
+    val recall1 = Recall(::RecallId.random(), NomsNumber("123456"), createdByUserId, now, now)
+    val recall2 = Recall(::RecallId.random(), NomsNumber("987654"), createdByUserId, now, now)
     recallRepository.save(recall1)
     recallRepository.save(recall2)
 
@@ -26,8 +28,8 @@ class GetRecallsComponentTest : ComponentTestBase() {
     assertThat(
       response, List<RecallResponse>::containsAll,
       listOf(
-        RecallResponse(recall1.recallId(), recall1.nomsNumber, now, now),
-        RecallResponse(recall2.recallId(), recall2.nomsNumber, now, now)
+        RecallResponse(recall1.recallId(), recall1.nomsNumber, createdByUserId, now, now),
+        RecallResponse(recall2.recallId(), recall2.nomsNumber, createdByUserId, now, now)
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/SearchRecallsComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/SearchRecallsComponentTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallSearchRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import java.time.Instant
@@ -18,10 +19,11 @@ class SearchRecallsComponentTest : ComponentTestBase() {
   fun `search recalls by nomsNumber`() {
     val nomsNumberToSearch = randomNoms()
     val now = OffsetDateTime.ofInstant(Instant.parse("2021-10-04T14:15:43.682078Z"), ZoneId.of("UTC"))
-    val recall1 = Recall(::RecallId.random(), randomNoms(), now, now)
-    val recall2 = Recall(::RecallId.random(), nomsNumberToSearch, now, now)
-    val recall3 = Recall(::RecallId.random(), nomsNumberToSearch, now, now)
-    val recall4 = Recall(::RecallId.random(), randomNoms(), now, now)
+    val createdByUserId = ::UserId.random()
+    val recall1 = Recall(::RecallId.random(), randomNoms(), createdByUserId, now, now)
+    val recall2 = Recall(::RecallId.random(), nomsNumberToSearch, createdByUserId, now, now)
+    val recall3 = Recall(::RecallId.random(), nomsNumberToSearch, createdByUserId, now, now)
+    val recall4 = Recall(::RecallId.random(), randomNoms(), createdByUserId, now, now)
     recallRepository.saveAll(listOf(recall1, recall2, recall3, recall4))
 
     val response = authenticatedClient.searchRecalls(RecallSearchRequest(nomsNumberToSearch))
@@ -29,8 +31,8 @@ class SearchRecallsComponentTest : ComponentTestBase() {
     assertThat(
       response, List<RecallResponse>::equals,
       listOf(
-        RecallResponse(recall2.recallId(), nomsNumberToSearch, now, now),
-        RecallResponse(recall3.recallId(), nomsNumberToSearch, now, now)
+        RecallResponse(recall2.recallId(), nomsNumberToSearch, createdByUserId, now, now),
+        RecallResponse(recall3.recallId(), nomsNumberToSearch, createdByUserId, now, now)
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/UpdateRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/UpdateRecallComponentTest.kt
@@ -43,12 +43,14 @@ class UpdateRecallComponentTest : ComponentTestBase() {
 
   private lateinit var recallId: RecallId
   private lateinit var recallPath: String
+  private lateinit var createdByUserId: UserId
 
   @BeforeEach
   fun setupExistingRecall() {
     recallId = ::RecallId.random()
     recallPath = "/recalls/$recallId"
-    recallRepository.save(Recall(recallId, nomsNumber, now, now))
+    createdByUserId = ::UserId.random()
+    recallRepository.save(Recall(recallId, nomsNumber, createdByUserId, now, now))
     val instant = Instant.parse("2021-10-04T13:15:50.00Z")
     fixedClockTime = OffsetDateTime.ofInstant(instant, zone)
     every { fixedClock.instant() } returns instant
@@ -65,6 +67,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           lastReleasePrison = PrisonId("MWI"),
@@ -135,6 +138,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           recallLength = TWENTY_EIGHT_DAYS,
@@ -160,6 +164,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           bookingNumber = bookingNumber
@@ -179,6 +184,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           localPoliceForce = policeForce
@@ -204,6 +210,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           licenceConditionsBreached = "Breached",
@@ -230,6 +237,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           agreeWithRecall = AgreeWithRecall.YES,
@@ -253,6 +261,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           recallNotificationEmailSentDateTime = updateRecallRequest.recallNotificationEmailSentDateTime,
@@ -278,6 +287,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           dossierEmailSentDate = updateRecallRequest.dossierEmailSentDate,
@@ -303,6 +313,7 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           fixedClockTime,
           additionalLicenceConditions = request.additionalLicenceConditions,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallResponseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallResponseTest.kt
@@ -7,38 +7,30 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
-import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import java.time.OffsetDateTime
 
 class RecallResponseTest {
 
+  private val recallResponse = RecallResponse(
+    ::RecallId.random(), NomsNumber("A12345AA"), ::UserId.random(), OffsetDateTime.now(), OffsetDateTime.now()
+  )
+
   @Test
   fun `RecallResponse without recallNotificationEmailSentDateTime or bookedByUserId set returns null status`() {
-    val recall = RecallResponse(
-      ::RecallId.random(),
-      NomsNumber("A12345AA"),
-      OffsetDateTime.now(),
-      OffsetDateTime.now()
-    )
-
-    assertThat(recall.status, equalTo(null))
+    assertThat(recallResponse.status, equalTo(null))
   }
 
   @Test
   fun `RecallResponse with bookedByUserId set but without recallNotificationEmailSentDateTime set returns status BOOKED_ON`() {
-    val recall = RecallResponse(
-      ::RecallId.random(), NomsNumber("A12345AA"), OffsetDateTime.now(), OffsetDateTime.now(), bookedByUserId = ::UserId.random()
+    val recall = recallResponse.copy(
+      bookedByUserId = ::UserId.random()
     )
     assertThat(recall.status, equalTo(Status.BOOKED_ON))
   }
 
   @Test
   fun `RecallResponse with bookedByUserId and assignee set but without recallNotificationEmailSentDateTime set returns status IN_ASSESSMENT`() {
-    val recall = RecallResponse(
-      ::RecallId.random(),
-      NomsNumber("A12345AA"),
-      OffsetDateTime.now(),
-      OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       bookedByUserId = ::UserId.random(),
       assignee = ::UserId.random()
     )
@@ -47,9 +39,7 @@ class RecallResponseTest {
 
   @Test
   fun `RecallResponse with recallNotificationEmailSentDateTime set returns status RECALL_NOTIFICATION_ISSUED`() {
-    val recall = RecallResponse(
-      ::RecallId.random(), NomsNumber("A12345AA"), OffsetDateTime.now(),
-      OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       recallNotificationEmailSentDateTime = OffsetDateTime.now()
     )
 
@@ -58,11 +48,7 @@ class RecallResponseTest {
 
   @Test
   fun `RecallResponse with recallNotificationEmailSentDateTime set and bookedByUserId set returns status RECALL_NOTIFICATION_ISSUED`() {
-    val recall = RecallResponse(
-      ::RecallId.random(),
-      NomsNumber("A12345AA"),
-      OffsetDateTime.now(),
-      OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       recallNotificationEmailSentDateTime = OffsetDateTime.now(),
       bookedByUserId = ::UserId.random()
     )
@@ -72,11 +58,7 @@ class RecallResponseTest {
 
   @Test
   fun `RecallResponse with recallNotificationEmailSentDateTime set and bookedByUserId set and assignee populated returns status DOSSIER_IN_PROGRESS`() {
-    val recall = RecallResponse(
-      ::RecallId.random(),
-      NomsNumber("A12345AA"),
-      OffsetDateTime.now(),
-      OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       recallNotificationEmailSentDateTime = OffsetDateTime.now(),
       bookedByUserId = ::UserId.random(),
       assignee = ::UserId.random()
@@ -87,8 +69,7 @@ class RecallResponseTest {
 
   @Test
   fun `RecallResponse with dossierCreatedByUserId set returns status DOSSIER_ISSUED`() {
-    val recall = RecallResponse(
-      ::RecallId.random(), randomNoms(), OffsetDateTime.now(), OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       dossierCreatedByUserId = ::UserId.random()
     )
 
@@ -97,8 +78,7 @@ class RecallResponseTest {
 
   @Test
   fun `RecallResponse with recallNotificationEmailSentDateTime set and bookedByUserId set and assignee and dossierCreatedByUserId set returns status DOSSIER_ISSUED`() {
-    val recall = RecallResponse(
-      ::RecallId.random(), randomNoms(), OffsetDateTime.now(), OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       recallNotificationEmailSentDateTime = OffsetDateTime.now(),
       bookedByUserId = ::UserId.random(),
       assignee = ::UserId.random(),
@@ -110,8 +90,7 @@ class RecallResponseTest {
 
   @Test
   fun `RecallResponse with dossierCreatedByUserId set and recallNotificationEmailSentDateTime set and bookedByUserId set returns status DOSSIER_ISSUED`() {
-    val recall = RecallResponse(
-      ::RecallId.random(), randomNoms(), OffsetDateTime.now(), OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       recallNotificationEmailSentDateTime = OffsetDateTime.now(),
       bookedByUserId = ::UserId.random(),
       dossierCreatedByUserId = ::UserId.random(),
@@ -123,8 +102,7 @@ class RecallResponseTest {
   @Test
   fun `RecallResponse with recallEmailReceivedDateTime set returns recallAssessmentDueDateTime as 24 hours later`() {
     val dateTime = OffsetDateTime.now()
-    val recall = RecallResponse(
-      ::RecallId.random(), randomNoms(), OffsetDateTime.now(), OffsetDateTime.now(),
+    val recall = recallResponse.copy(
       recallEmailReceivedDateTime = dateTime
     )
 
@@ -133,10 +111,6 @@ class RecallResponseTest {
 
   @Test
   fun `RecallResponse without recallEmailReceivedDateTime set returns recallAssessmentDueDateTime as null`() {
-    val recall = RecallResponse(
-      ::RecallId.random(), randomNoms(), OffsetDateTime.now(), OffsetDateTime.now()
-    )
-
-    assertThat(recall.recallAssessmentDueDateTime, equalTo(null))
+    assertThat(recallResponse.recallAssessmentDueDateTime, equalTo(null))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallsControllerTest.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomString
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.CourtValidationService
-import uk.gov.justice.digital.hmpps.managerecallsapi.service.DocumentService
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.PrisonValidationService
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.RecallService
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.UserDetailsService
@@ -39,7 +38,6 @@ import java.util.UUID
 class RecallsControllerTest {
   private val recallRepository = mockk<RecallRepository>()
   private val recallNotificationService = mockk<RecallNotificationService>()
-  private val documentService = mockk<DocumentService>()
   private val dossierService = mockk<DossierService>()
   private val letterToPrisonService = mockk<LetterToPrisonService>()
   private val userDetailsService = mockk<UserDetailsService>()
@@ -51,7 +49,6 @@ class RecallsControllerTest {
     RecallsController(
       recallRepository,
       recallNotificationService,
-      documentService,
       dossierService,
       letterToPrisonService,
       userDetailsService,
@@ -62,9 +59,15 @@ class RecallsControllerTest {
 
   private val recallId = ::RecallId.random()
   private val nomsNumber = NomsNumber("A1234AA")
-  private val recallRequest = BookRecallRequest(nomsNumber)
+  private val createdByUserId = ::UserId.random()
+  private val recallRequest = BookRecallRequest(nomsNumber, createdByUserId)
   private val fileName = "fileName"
   private val now = OffsetDateTime.now()
+
+  private val recall = Recall(recallId, nomsNumber, createdByUserId, now, now)
+
+  private val updateRecallRequest =
+    UpdateRecallRequest(lastReleasePrison = PrisonId("ABC"), currentPrison = PrisonId("DEF"))
 
   @Test
   fun `book recall returns request with id`() {
@@ -74,19 +77,17 @@ class RecallsControllerTest {
 
     val results = underTest.bookRecall(recallRequest)
 
-    val expected = RecallResponse(recall.recallId(), nomsNumber, now, now)
+    val expected = RecallResponse(recall.recallId(), nomsNumber, createdByUserId, now, now)
     assertThat(results.body, equalTo(expected))
   }
 
   @Test
   fun `gets all recalls`() {
-    val recall = Recall(recallId, nomsNumber, now, now)
-
     every { recallRepository.findAll() } returns listOf(recall)
 
     val results = underTest.findAll()
 
-    assertThat(results, equalTo(listOf(RecallResponse(recallId, nomsNumber, now, now))))
+    assertThat(results, equalTo(listOf(RecallResponse(recallId, nomsNumber, createdByUserId, now, now))))
   }
 
   @Test
@@ -101,11 +102,7 @@ class RecallsControllerTest {
     )
     val recallEmailReceivedDateTime = now
     val lastReleaseDate = LocalDate.now()
-    val recall = Recall(
-      recallId,
-      nomsNumber,
-      now,
-      now,
+    val recall = recall.copy(
       documents = setOf(document),
       lastReleasePrison = PrisonId("BEL"),
       lastReleaseDate = lastReleaseDate,
@@ -118,6 +115,7 @@ class RecallsControllerTest {
     val expected = RecallResponse(
       recallId,
       nomsNumber,
+      createdByUserId,
       now,
       now,
       documents = listOf(ApiRecallDocument(document.id(), document.category, fileName)),
@@ -188,7 +186,7 @@ class RecallsControllerTest {
   @Test
   fun `set assignee for recall`() {
     val assignee = ::UserId.random()
-    val assignedRecall = Recall(recallId, nomsNumber, now, now, assignee = assignee)
+    val assignedRecall = recall.copy(assignee = assignee.value)
 
     every { recallService.assignRecall(recallId, assignee) } returns assignedRecall
     every { userDetailsService.find(assignee) } returns UserDetails(
@@ -204,6 +202,7 @@ class RecallsControllerTest {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           now,
           assignee = assignee,
@@ -216,7 +215,7 @@ class RecallsControllerTest {
   @Test
   fun `set assignee for recall without user details`() {
     val assignee = ::UserId.random()
-    val assignedRecall = Recall(recallId, nomsNumber, now, now, assignee = assignee)
+    val assignedRecall = recall.copy(assignee = assignee.value)
 
     every { recallService.assignRecall(recallId, assignee) } returns assignedRecall
     every { userDetailsService.find(assignee) } returns null
@@ -229,6 +228,7 @@ class RecallsControllerTest {
         RecallResponse(
           recallId,
           nomsNumber,
+          createdByUserId,
           now,
           now,
           assignee = assignee,
@@ -241,19 +241,14 @@ class RecallsControllerTest {
   @Test
   fun `unassign recall`() {
     val assignee = ::UserId.random()
-    val unassignedRecall = Recall(recallId, nomsNumber, now, now)
+    val unassignedRecall = recall
 
     every { recallService.unassignRecall(recallId, assignee) } returns unassignedRecall
 
     val result = underTest.unassignRecall(recallId, assignee)
 
-    assertThat(result, equalTo(RecallResponse(recallId, nomsNumber, now, now)))
+    assertThat(result, equalTo(RecallResponse(recallId, nomsNumber, createdByUserId, now, now)))
   }
-
-  private val recall = Recall(recallId, nomsNumber, now, now)
-
-  private val updateRecallRequest =
-    UpdateRecallRequest(lastReleasePrison = PrisonId("ABC"), currentPrison = PrisonId("DEF"))
 
   @Test
   fun `can update recall and return a response with all fields populated`() {
@@ -264,7 +259,7 @@ class RecallsControllerTest {
 
     val response = underTest.updateRecall(recallId, updateRecallRequest)
 
-    assertThat(response, equalTo(ResponseEntity.ok(RecallResponse(recallId, nomsNumber, now, now))))
+    assertThat(response, equalTo(ResponseEntity.ok(RecallResponse(recallId, nomsNumber, createdByUserId, now, now))))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextFactoryTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.search.Prisoner
 import uk.gov.justice.digital.hmpps.managerecallsapi.search.PrisonerOffenderSearchClient
@@ -35,7 +36,7 @@ class DossierContextFactoryTest {
     val currentPrison = PrisonId("AAA")
     val currentPrisonName = PrisonName("Current Prison Name")
     val prisoner = mockk<Prisoner>()
-    val recall = Recall(recallId, nomsNumber, OffsetDateTime.now(), currentPrison = currentPrison)
+    val recall = Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), currentPrison = currentPrison)
 
     every { recallRepository.getByRecallId(recallId) } returns recall
     every { prisonerOffenderSearchClient.prisonerSearch(SearchRequest(nomsNumber)) } returns Mono.just(listOf(prisoner))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PersonName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.search.Prisoner
 import java.time.OffsetDateTime
@@ -21,7 +22,7 @@ class DossierContextTest {
   private val lastName = "Badger"
   private val recall = Recall(
     ::RecallId.random(),
-    nomsNumber, OffsetDateTime.now(),
+    nomsNumber, ::UserId.random(), OffsetDateTime.now(),
     OffsetDateTime.now(),
     bookingNumber = bookingNumber,
     licenceConditionsBreached = licenceConditionsBreached

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonConfirmationHtmlGenerationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonConfirmationHtmlGenerationTest.kt
@@ -32,7 +32,7 @@ class LetterToPrisonConfirmationHtmlGenerationTest(@Autowired private val templa
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), OffsetDateTime.now(),
+            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(),
             recallLength = recallLength,
             bookingNumber = "B1234",
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonContextFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonContextFactoryTest.kt
@@ -39,8 +39,8 @@ class LetterToPrisonContextFactoryTest {
     val assessedByUserId = ::UserId.random()
     val recallLength = RecallLength.TWENTY_EIGHT_DAYS
     val recall = Recall(
-      recallId, NomsNumber("AA1234A"), OffsetDateTime.now(),
-      OffsetDateTime.now(),
+      recallId, NomsNumber("AA1234A"), ::UserId.random(),
+      OffsetDateTime.now(), OffsetDateTime.now(),
       lastReleasePrison = PrisonId("BOB"),
       currentPrison = PrisonId("WIM"),
       assessedByUserId = assessedByUserId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonCustodyOfficeHtmlGenerationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonCustodyOfficeHtmlGenerationTest.kt
@@ -37,7 +37,7 @@ class LetterToPrisonCustodyOfficeHtmlGenerationTest(@Autowired private val templ
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), OffsetDateTime.now(),
+            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(),
             recallLength = recallLength,
             contraband = true,
             contrabandDetail = "Because...",
@@ -70,7 +70,7 @@ class LetterToPrisonCustodyOfficeHtmlGenerationTest(@Autowired private val templ
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), OffsetDateTime.now(),
+            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(),
             recallLength = recallLength,
             bookingNumber = "B1234",
             differentNomsNumber = true,
@@ -103,7 +103,7 @@ class LetterToPrisonCustodyOfficeHtmlGenerationTest(@Autowired private val templ
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), OffsetDateTime.now(),
+            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(),
             recallLength = recallLength,
             contraband = true,
             contrabandDetail = "Because...",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonGovernorHtmlGenerationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonGovernorHtmlGenerationTest.kt
@@ -37,7 +37,7 @@ class LetterToPrisonGovernorHtmlGenerationTest(@Autowired private val templateEn
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), OffsetDateTime.now(),
+            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(),
             recallLength = recallLength,
             lastReleaseDate = LocalDate.of(2020, 10, 1),
             bookingNumber = "B1234"
@@ -62,7 +62,7 @@ class LetterToPrisonGovernorHtmlGenerationTest(@Autowired private val templateEn
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), OffsetDateTime.now(),
+            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(),
             recallLength = recallLength,
             lastReleaseDate = LocalDate.of(2020, 10, 1),
             bookingNumber = "B1234"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonServiceParameterizedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonServiceParameterizedTest.kt
@@ -76,7 +76,7 @@ internal class LetterToPrisonServiceParameterizedTest {
   @ParameterizedTest
   @MethodSource("letterToPrisonParameters")
   fun `creates a letter to prison for a recall `(recallLength: RecallLength, annexHeaderText: String) {
-    val aRecall = Recall(recallId, nomsNumber, OffsetDateTime.now(), recallLength = recallLength)
+    val aRecall = Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), recallLength = recallLength)
     val documentId = ::DocumentId.random()
     val assessor = UserDetails(
       ::UserId.random(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextFactoryTest.kt
@@ -68,6 +68,7 @@ class RecallNotificationContextFactoryTest {
     val recall = Recall(
       recallId,
       nomsNumber,
+      ::UserId.random(),
       OffsetDateTime.now(),
       OffsetDateTime.now(),
       lastReleasePrison = lastReleasePrisonId,
@@ -119,8 +120,7 @@ class RecallNotificationContextFactoryTest {
     val sentencingInfo =
       SentencingInfo(LocalDate.now(), LocalDate.now(), LocalDate.now(), sentencingCourtId, "", SentenceLength(3, 1, 0))
     val recall = Recall(
-      recallId, nomsNumber, OffsetDateTime.now(),
-      OffsetDateTime.now(),
+      recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), OffsetDateTime.now(),
       lastReleasePrison = lastReleasePrisonId,
       lastReleaseDate = LocalDate.now(),
       localPoliceForce = "A Force",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.zeroes
 import uk.gov.justice.digital.hmpps.managerecallsapi.search.Prisoner
 import java.time.Clock
@@ -47,8 +48,7 @@ class RecallNotificationContextTest {
   private val probationOfficerName = "Mr Probation Officer"
 
   private val recall = Recall(
-    recallId, NomsNumber("AA1234A"), OffsetDateTime.now(),
-    OffsetDateTime.now(),
+    recallId, NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), OffsetDateTime.now(),
     recallLength = recallLength,
     lastReleaseDate = lastReleaseDate,
     localPoliceForce = "London",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/DocumentRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/DocumentRepositoryIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallDocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomUnVersionedDocumentCategory
@@ -36,6 +37,7 @@ class DocumentRepositoryIntegrationTest(
 
   private val recallId = ::RecallId.random()
   private val nomsNumber = randomNoms()
+  private val recall = Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now())
   private val versioneDocumentId = ::DocumentId.random()
   // TODO: parameterized tests driven from RecallDocumentCategory
   private val versionedCategory = randomVersionedDocumentCategory()
@@ -46,7 +48,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `can save and flush two distinct copies of an un-versioned document for an existing recall`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
 
     val idOne = ::DocumentId.random()
     val docOne = unVersionedDocument(idOne, recallId, unVersionedCategory)
@@ -65,7 +67,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `can save and flush two distinct copies of an versioned document with different versions for an existing recall`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
 
     val idOne = ::DocumentId.random()
     val docOne = versionedDocument(idOne, recallId, versionedCategory, 1)
@@ -84,7 +86,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `cannot save and flush two distinct copies of an versioned document with the same version for an existing recall throws DataIntegrityViolationException`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
 
     val idOne = ::DocumentId.random()
     val docOne = versionedDocument(idOne, recallId, versionedCategory, 1)
@@ -101,7 +103,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `cannot save and flush a versioned document with null version for an existing recall throws DataIntegrityViolationException`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
 
     val id = ::DocumentId.random()
     val document = versionedDocument(id, recallId, versionedCategory, 1).copy(version = null)
@@ -115,7 +117,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `cannot save and flush an un-versioned document with non-null version for an existing recall throws DataIntegrityViolationException`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
 
     val id = ::DocumentId.random()
     val document = unVersionedDocument(id, recallId, unVersionedCategory).copy(version = 1)
@@ -129,7 +131,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `getByRecallIdAndDocumentId for an existing recall`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
     documentRepository.save(versionedRecallDocument)
 
     val retrieved = documentRepository.getByRecallIdAndDocumentId(recallId, versioneDocumentId)
@@ -153,7 +155,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `findByRecallIdAndCategory for an existing recall`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
     documentRepository.save(versionedRecallDocument)
 
     val retrieved = documentRepository.findByRecallIdAndCategory(recallId.value, versionedCategory)
@@ -164,7 +166,7 @@ class DocumentRepositoryIntegrationTest(
   @Test
   @Transactional
   fun `findByRecallIdAndCategory returns null if no document exists`() {
-    recallRepository.save(Recall(recallId, nomsNumber, OffsetDateTime.now()))
+    recallRepository.save(recall)
 
     val retrieved = documentRepository.findByRecallIdAndCategory(recallId.value, versionedCategory)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/RecallRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/RecallRepositoryIntegrationTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallDocumentCategory.P
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.fullyPopulatedRecall
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
@@ -36,9 +37,10 @@ class RecallRepositoryIntegrationTest(
   @Qualifier("jpaDocumentRepository") @Autowired private val jpaDocumentRepository: JpaDocumentRepository,
 ) {
   private val nomsNumber = randomNoms()
+  private val createdByUserId = ::UserId.random()
   private val recallId = ::RecallId.random()
   private val now = OffsetDateTime.now()
-  private val recall = Recall(recallId, nomsNumber, now, now)
+  private val recall = Recall(recallId, nomsNumber, createdByUserId, now, now)
 
   private val repository = RecallRepository(jpaRepository)
   private val documentRepository = DocumentRepository(jpaDocumentRepository)
@@ -50,7 +52,7 @@ class RecallRepositoryIntegrationTest(
 
     val retrieved = repository.getByRecallId(recallId)
 
-    assertThat(retrieved, equalTo(Recall(recallId, nomsNumber, now, now)))
+    assertThat(retrieved, equalTo(recall))
   }
 
   @Test
@@ -82,7 +84,7 @@ class RecallRepositoryIntegrationTest(
 
     val retrieved = repository.findByRecallId(recallId)
 
-    assertThat(retrieved, equalTo(Recall(recallId, nomsNumber, now, now)))
+    assertThat(retrieved, equalTo(recall))
   }
 
   @Test
@@ -97,7 +99,7 @@ class RecallRepositoryIntegrationTest(
 
     val retrieved = repository.findByNomsNumber(nomsNumber)
 
-    assertThat(retrieved, equalTo(listOf(Recall(recallId, nomsNumber, now, now))))
+    assertThat(retrieved, equalTo(listOf(recall)))
   }
 
   @Test
@@ -115,7 +117,7 @@ class RecallRepositoryIntegrationTest(
 
     val retrieved = repository.search(RecallSearchRequest(nomsNumber))
 
-    assertThat(retrieved, equalTo(listOf(Recall(recallId, nomsNumber, now, now))))
+    assertThat(retrieved, equalTo(listOf(recall)))
   }
 
   @Test
@@ -138,9 +140,7 @@ class RecallRepositoryIntegrationTest(
       1,
       now
     )
-    val recallToUpdate = Recall(
-      recallId, nomsNumber, now,
-      now,
+    val recallToUpdate = recall.copy(
       documents = setOf(
         document
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/DossierGenerationGotenbergComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/DossierGenerationGotenbergComponentTest.kt
@@ -20,7 +20,7 @@ class DossierGenerationGotenbergComponentTest : GotenbergComponentTestBase() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
     setupUserDetailsFor(recallNotificationUserId)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber))
+    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, ::UserId.random()))
     updateRecallWithRequiredInformationForTheDossier(recall.recallId)
     authenticatedClient.getRecallNotification(recall.recallId, recallNotificationUserId)
     expectNoVirusesWillBeFound()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/LetterToPrisonGotenbergComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/LetterToPrisonGotenbergComponentTest.kt
@@ -20,7 +20,7 @@ class LetterToPrisonGotenbergComponentTest : GotenbergComponentTestBase() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
     setupUserDetailsFor(assessedByUserId)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber))
+    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, ::UserId.random()))
     updateRecallWithRequiredInformationForTheLetterToPrison(
       recall.recallId,
       assessedByUserId = assessedByUserId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/RecallNotificationGotenbergComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/RecallNotificationGotenbergComponentTest.kt
@@ -15,6 +15,7 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
   private val loremIpsum =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
   private val nomsNumber = NomsNumber("123456")
+  private val createdByUserId = ::UserId.random()
   private val prisonerFirstName = "Natalia"
   private val userIdGeneratingTheRecallNotification = ::UserId.random()
 
@@ -23,7 +24,7 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
     setupUserDetailsFor(userIdGeneratingTheRecallNotification)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber))
+    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, createdByUserId))
     updateRecallWithRequiredInformationForTheDossier(recall.recallId)
 
     val recallNotification = authenticatedClient.getRecallNotification(recall.recallId, userIdGeneratingTheRecallNotification)
@@ -38,7 +39,7 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
     setupUserDetailsFor(userIdGeneratingTheRecallNotification)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber))
+    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, createdByUserId))
     updateRecallWithRequiredInformationForTheDossier(
       recall.recallId,
       contraband = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/DocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/DocumentServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomString
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomVersionedDocumentCategory
@@ -55,7 +56,7 @@ internal class DocumentServiceTest {
   private val recallId = ::RecallId.random()
   private val documentBytes = randomString().toByteArray()
   private val nomsNumber = NomsNumber("A1235B")
-  private val aRecallWithoutDocuments = Recall(recallId, nomsNumber, OffsetDateTime.now())
+  private val aRecallWithoutDocuments = Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now())
   private val documentCategory = PART_A_RECALL_REPORT
   private val fileName = randomString()
 
@@ -119,11 +120,7 @@ internal class DocumentServiceTest {
       1,
       OffsetDateTime.now(fixedClock)
     )
-    val aRecallWithDocument = Recall(
-      recallId,
-      nomsNumber,
-      OffsetDateTime.now(),
-      OffsetDateTime.now(),
+    val aRecallWithDocument = aRecallWithoutDocuments.copy(
       documents = setOf(existingDocument)
     )
     val newFileName = randomString()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceTest.kt
@@ -43,7 +43,7 @@ class RecallServiceTest {
   private val underTest = RecallService(recallRepository, bankHolidayService, fixedClock)
 
   private val recallId = ::RecallId.random()
-  private val existingRecall = Recall(recallId, NomsNumber("A9876ZZ"), OffsetDateTime.now())
+  private val existingRecall = Recall(recallId, NomsNumber("A9876ZZ"), ::UserId.random(), OffsetDateTime.now())
   private val today = LocalDate.now()
 
   private val fullyPopulatedUpdateRecallRequest: UpdateRecallRequest = fullyPopulatedInstance<UpdateRecallRequest>().copy(recallNotificationEmailSentDateTime = OffsetDateTime.now(fixedClock))
@@ -194,9 +194,11 @@ class RecallServiceTest {
   fun `can assign a recall`() {
     val nomsNumber = randomNoms()
     val now = OffsetDateTime.now()
-    val recall = Recall(recallId, nomsNumber, now, now)
+    val createdByUserId = ::UserId.random()
+
+    val recall = Recall(recallId, nomsNumber, createdByUserId, now, now)
     val assignee = ::UserId.random()
-    val expected = Recall(recallId, nomsNumber, now, OffsetDateTime.now(fixedClock), assignee = assignee)
+    val expected = Recall(recallId, nomsNumber, createdByUserId, now, OffsetDateTime.now(fixedClock), assignee = assignee)
 
     every { recallRepository.getByRecallId(recallId) } returns recall
     every { recallRepository.save(expected) } returns expected
@@ -209,11 +211,12 @@ class RecallServiceTest {
   fun `can unassign a recall`() {
     val nomsNumber = randomNoms()
     val now = OffsetDateTime.now()
-    val recall = Recall(recallId, nomsNumber, now, now)
+    val createdByUserId = ::UserId.random()
+    val recall = Recall(recallId, nomsNumber, createdByUserId, now, now)
     val assignee = ::UserId.random()
     val expected = recall.copy(lastUpdatedDateTime = OffsetDateTime.now(fixedClock))
 
-    every { recallRepository.getByRecallId(recallId) } returns Recall(recallId, nomsNumber, now, now, assignee = assignee)
+    every { recallRepository.getByRecallId(recallId) } returns Recall(recallId, nomsNumber, createdByUserId, now, now, assignee = assignee)
     every { recallRepository.save(expected) } returns expected
 
     val assignedRecall = underTest.unassignRecall(recallId, assignee)
@@ -226,8 +229,9 @@ class RecallServiceTest {
     val assignee = ::UserId.random()
     val otherAssignee = ::UserId.random()
     val nomsNumber = randomNoms()
+    val createdByUserId = ::UserId.random()
 
-    every { recallRepository.getByRecallId(recallId) } returns Recall(recallId, nomsNumber, OffsetDateTime.now(), OffsetDateTime.now(), assignee = assignee)
+    every { recallRepository.getByRecallId(recallId) } returns Recall(recallId, nomsNumber, createdByUserId, OffsetDateTime.now(), OffsetDateTime.now(), assignee = assignee)
 
     assertThrows<NotFoundException> { underTest.unassignRecall(recallId, otherAssignee) }
   }


### PR DESCRIPTION
Failing PACT v Pre-Prod as expected since not sending `createdByUserId`