### PR TITLE
PUD-816: Enable prometheus metrics and include upstream health metrics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ configurations {
 }
 
 dependencies {
+  implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("io.micrometer:micrometer-registry-prometheus")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/ResourceServerConfiguration.kt
@@ -29,6 +29,7 @@ class ResourceServerConfiguration : WebSecurityConfigurerAdapter() {
           .antMatchers(
             "/health/**",
             "/reference-data/**",
+            "/prometheus",
             "/info",
             "/v2/**",
             "/v3/**",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/BankHolidayHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/BankHolidayHealth.kt
@@ -7,5 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 @Component("bankHoliday")
 class BankHolidayHealth(
   webClient: WebClient,
+  @Value("bankHoliday") componentName: String,
   @Value("\${bankHolidayRegister.endpoint.url}") endpointUrl: String
-) : PingHealthCheck(webClient, endpointUrl)
+) : PingHealthCheck(webClient, componentName, endpointUrl)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/CourtRegisterHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/CourtRegisterHealth.kt
@@ -7,5 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 @Component("courtRegister")
 class CourtRegisterHealth(
   webClient: WebClient,
+  @Value("courtRegister") componentName: String,
   @Value("\${courtRegister.endpoint.url}") prisonRegisterEndpointUrl: String
-) : PingHealthCheck(webClient, "$prisonRegisterEndpointUrl/health/ping")
+) : PingHealthCheck(webClient, componentName,"$prisonRegisterEndpointUrl/health/ping")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/CourtRegisterHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/CourtRegisterHealth.kt
@@ -9,4 +9,4 @@ class CourtRegisterHealth(
   webClient: WebClient,
   @Value("courtRegister") componentName: String,
   @Value("\${courtRegister.endpoint.url}") prisonRegisterEndpointUrl: String
-) : PingHealthCheck(webClient, componentName,"$prisonRegisterEndpointUrl/health/ping")
+) : PingHealthCheck(webClient, componentName, "$prisonRegisterEndpointUrl/health/ping")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/GotenbergHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/GotenbergHealth.kt
@@ -7,5 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 @Component("gotenberg")
 class GotenbergHealth(
   webClient: WebClient,
+  @Value("gotenberg") componentName: String,
   @Value("\${gotenberg.endpoint.url}") gotenbergEndpointUrl: String
-) : PingHealthCheck(webClient, "$gotenbergEndpointUrl/ping")
+) : PingHealthCheck(webClient, componentName, "$gotenbergEndpointUrl/ping")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/HmppsAuthHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/HmppsAuthHealth.kt
@@ -7,5 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 @Component("hmppsAuth")
 class HmppsAuthHealth(
   webClient: WebClient,
+  @Value("hmppsAuth") componentName: String,
   @Value("\${oauth.endpoint.url}") hmppsAuthEndpointUrl: String
-) : PingHealthCheck(webClient, "$hmppsAuthEndpointUrl/health/ping")
+) : PingHealthCheck(webClient, componentName, "$hmppsAuthEndpointUrl/health/ping")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/PingHealthCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/PingHealthCheck.kt
@@ -13,7 +13,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 import java.time.Duration
 
-
 abstract class PingHealthCheck(
   private val webClient: WebClient,
   private val componentName: String,
@@ -40,7 +39,7 @@ abstract class PingHealthCheck(
   }
 
   private fun recordHealthMetric(result: Health?) {
-    var gaugeVal= 0
+    var gaugeVal = 0
 
     if (result?.status == Status.UP) {
       gaugeVal = 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/PrisonRegisterHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/PrisonRegisterHealth.kt
@@ -7,5 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 @Component("prisonRegister")
 class PrisonRegisterHealth(
   webClient: WebClient,
+  @Value("prisonRegister") componentName: String,
   @Value("\${prisonRegister.endpoint.url}") prisonRegisterEndpointUrl: String
-) : PingHealthCheck(webClient, "$prisonRegisterEndpointUrl/health/ping")
+) : PingHealthCheck(webClient, componentName, "$prisonRegisterEndpointUrl/health/ping")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/PrisonerOffenderSearchHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/PrisonerOffenderSearchHealth.kt
@@ -7,5 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 @Component("prisonerOffenderSearch")
 class PrisonerOffenderSearchHealth(
   webClient: WebClient,
+  @Value("prisonerOffenderSearch") componentName: String,
   @Value("\${prisonerSearch.endpoint.url}") prisonerSearchEndpointUrl: String
-) : PingHealthCheck(webClient, "$prisonerSearchEndpointUrl/health/ping")
+) : PingHealthCheck(webClient, componentName, "$prisonerSearchEndpointUrl/health/ping")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,7 +67,7 @@ management:
     web:
       base-path: /
       exposure:
-        include: 'info, health'
+        include: 'info,health,prometheus'
   endpoint:
     health:
       cache:


### PR DESCRIPTION
TODO: Expose the metrics to prometheus once I've confirmed the http request timing is appropriate on the cluster.