### PR TITLE
Explicitly enable the metrics endpoints

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,10 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
 
 prisonerSearch:
   endpoint:


### PR DESCRIPTION
The documentation is unclear as to whether they're all enabled by default or not...