### PR TITLE
Add suppression for OWASP failure. Thymeleaf isnt exposed to API, just used in transition to PDF.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Ignore until new version is available. Currently we dont expose the thymeleaf in any way that can cause an issue
+CVE-2021-43466

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   kotlin("plugin.spring") version "1.5.10"
   kotlin("plugin.jpa") version "1.5.20"
   kotlin("plugin.serialization") version "1.4.31"
+  id("org.owasp.dependencycheck") version "6.5.0.1"
 }
 
 repositories {
@@ -15,6 +16,14 @@ configurations {
     exclude(group = "junit")
     exclude(group = "com.vaadin.external.google", module = "android-json")
   }
+}
+
+dependencyCheck {
+  // Fail the build when there is a finding with "medium" severity.
+  // failBuildOnCVSS = 4
+  // Only check the compile classpath and ignore findings in other configurations.
+  // scanConfigurations = ['debugCompileClasspath', 'acceptanceCompileClasspath', 'productionCompileClasspath']
+  suppressionFiles.add("$rootDir/owasp.suppression.xml")
 }
 
 dependencies {

--- a/owasp.suppression.xml
+++ b/owasp.suppression.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2021-12-01">
+        <notes><![CDATA[ file name: thymeleaf-3.0.12.RELEASE.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.thymeleaf/thymeleaf@.*$</packageUrl>
+        <cve>CVE-2021-43466</cve>
+    </suppress>
+    <suppress until="2021-12-01">
+        <notes><![CDATA[ file name: thymeleaf-spring5-3.0.12.RELEASE.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.thymeleaf/thymeleaf\-spring5@.*$</packageUrl>
+        <cve>CVE-2021-43466</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
Added OWASP suppression until 1 December, possibly a new version will be released by then.
![Screenshot 2021-11-18 at 11 53 06](https://user-images.githubusercontent.com/16935168/142410646-da710ef8-043e-4c6d-8aed-12429d7d5ad2.png)


