### PR TITLE
Only set the SENTRY_DSN in pre-prod and prod

### DIFF
--- a/helm_deploy/manage-recalls-api/values.yaml
+++ b/helm_deploy/manage-recalls-api/values.yaml
@@ -20,7 +20,6 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     GOTENBERG_ENDPOINT_URL: http://manage-recalls-api-gotenberg
-    SENTRY_DSN: https://ea6c4e03abe840319aee1bc1b2a6a58a@o345774.ingest.sentry.io/5940644
     SENTRY_IGNORED_EXCEPTIONS_FOR_TYPE: org.springframework.security.web.firewall.RequestRejectedException
     CLAMAV_HOSTNAME: manage-recalls-api-clamav
     CLAMAV_PORT: 3310

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,7 +17,6 @@ generic-service:
     MANAGE_RECALLS_API_BASE_URI: https://manage-recalls-api-dev.hmpps.service.justice.gov.uk
     PRISONREGISTER_ENDPOINT_URL:  https://prison-register-dev.hmpps.service.justice.gov.uk
     COURTREGISTER_ENDPOINT_URL:  https://court-register-dev.hmpps.service.justice.gov.uk
-    SENTRY_DSN: "DO_NOT_TRACK"
     SENTRY_ENVIRONMENT: DEV
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,7 @@ generic-service:
     MANAGE_RECALLS_API_BASE_URI: https://manage-recalls-api-preprod.hmpps.service.justice.gov.uk
     PRISONREGISTER_ENDPOINT_URL:  https://prison-register-preprod.hmpps.service.justice.gov.uk
     COURTREGISTER_ENDPOINT_URL:  https://court-register-preprod.hmpps.service.justice.gov.uk
+    SENTRY_DSN: https://ea6c4e03abe840319aee1bc1b2a6a58a@o345774.ingest.sentry.io/5940644
     SENTRY_ENVIRONMENT: PRE-PROD
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,7 @@ generic-service:
     MANAGE_RECALLS_API_BASE_URI: https://manage-recalls-api.hmpps.service.justice.gov.uk
     PRISONREGISTER_ENDPOINT_URL:  https://prison-register.hmpps.service.justice.gov.uk
     COURTREGISTER_ENDPOINT_URL:  https://court-register.hmpps.service.justice.gov.uk
+    SENTRY_DSN: https://ea6c4e03abe840319aee1bc1b2a6a58a@o345774.ingest.sentry.io/5940644
     SENTRY_ENVIRONMENT: PROD
 
 generic-prometheus-alerts:


### PR DESCRIPTION
The app crashes out with an invalid DSN, but starts up fine if none is
present.