### PR TITLE
Fix the YAML merge in helm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,6 @@ jobs:
                 --reset-values \
                 --timeout 5m \
                 --history-max 10 \
-                --values "values-${ENV_NAME}.yaml" \
                 --values "values-manage-recalls-${ENV_NAME}.yaml" \
                 --set "generic-service.image.tag=${APP_VERSION}")
 

--- a/helm_deploy/values-manage-recalls-dev.yaml
+++ b/helm_deploy/values-manage-recalls-dev.yaml
@@ -1,10 +1,21 @@
 ---
-# Per environment values which override defaults in manage-recalls-ui/values.yaml
+# Per environment values which override defaults in manage-recalls-api/values.yaml
 
 generic-service:
+  replicaCount: 2
+
   ingress:
     host: manage-recalls-api-new-dev.hmpps.service.justice.gov.uk
     tlsSecretName: manage-recalls-cert
+
+  env:
+    OAUTH_ENDPOINT_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
+    PRISONERSEARCH_ENDPOINT_URL: https://prisoner-offender-search-dev.prison.service.justice.gov.uk
+    MANAGE_RECALLS_API_BASE_URI: https://manage-recalls-api-dev.hmpps.service.justice.gov.uk
+    PRISONREGISTER_ENDPOINT_URL:  https://prison-register-dev.hmpps.service.justice.gov.uk
+    COURTREGISTER_ENDPOINT_URL:  https://court-register-dev.hmpps.service.justice.gov.uk
+    SENTRY_ENVIRONMENT: DEV
 
   namespace_secrets:
     manage-recalls-api-database:
@@ -18,6 +29,7 @@ generic-service:
       S3_BUCKET_NAME: "bucket_name"
 
 generic-prometheus-alerts:
+  alertSeverity: ppud-replacement-alerts
   extraDashboardTags:
     - manage-recalls
     - dev

--- a/helm_deploy/values-manage-recalls-preprod.yaml
+++ b/helm_deploy/values-manage-recalls-preprod.yaml
@@ -1,10 +1,22 @@
 ---
-# Per environment values which override defaults in manage-recalls-ui/values.yaml
+# Per environment values which override defaults in manage-recalls-api/values.yaml
 
 generic-service:
+  replicaCount: 2
+
   ingress:
     host: manage-recalls-api-new-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: manage-recalls-cert
+
+  env:
+    OAUTH_ENDPOINT_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
+    PRISONERSEARCH_ENDPOINT_URL: https://prisoner-offender-search-preprod.prison.service.justice.gov.uk
+    MANAGE_RECALLS_API_BASE_URI: https://manage-recalls-api-preprod.hmpps.service.justice.gov.uk
+    PRISONREGISTER_ENDPOINT_URL:  https://prison-register-preprod.hmpps.service.justice.gov.uk
+    COURTREGISTER_ENDPOINT_URL:  https://court-register-preprod.hmpps.service.justice.gov.uk
+    SENTRY_DSN: https://ea6c4e03abe840319aee1bc1b2a6a58a@o345774.ingest.sentry.io/5940644
+    SENTRY_ENVIRONMENT: PRE-PROD
 
   namespace_secrets:
     manage-recalls-api-database:
@@ -18,6 +30,8 @@ generic-service:
       S3_BUCKET_NAME: "bucket_name"
 
 generic-prometheus-alerts:
+  alertSeverity: ppud-replacement-preprod
   extraDashboardTags:
     - manage-recalls
-    - preprod
+    - pre-prod
+

--- a/helm_deploy/values-manage-recalls-prod.yaml
+++ b/helm_deploy/values-manage-recalls-prod.yaml
@@ -1,10 +1,22 @@
 ---
-# Per environment values which override defaults in manage-recalls-ui/values.yaml
+# Per environment values which override defaults in manage-recalls-api/values.yaml
 
 generic-service:
+  replicaCount: 4
+
   ingress:
     host: manage-recalls-api-new.hmpps.service.justice.gov.uk
     tlsSecretName: manage-recalls-cert
+
+  env:
+    OAUTH_ENDPOINT_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: https://sign-in.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
+    PRISONERSEARCH_ENDPOINT_URL: https://prisoner-offender-search.prison.service.justice.gov.uk
+    MANAGE_RECALLS_API_BASE_URI: https://manage-recalls-api.hmpps.service.justice.gov.uk
+    PRISONREGISTER_ENDPOINT_URL:  https://prison-register.hmpps.service.justice.gov.uk
+    COURTREGISTER_ENDPOINT_URL:  https://court-register.hmpps.service.justice.gov.uk
+    SENTRY_DSN: https://ea6c4e03abe840319aee1bc1b2a6a58a@o345774.ingest.sentry.io/5940644
+    SENTRY_ENVIRONMENT: PROD
 
   namespace_secrets:
     manage-recalls-api-database:
@@ -18,6 +30,7 @@ generic-service:
       S3_BUCKET_NAME: "bucket_name"
 
 generic-prometheus-alerts:
+  alertSeverity: ppud-replacement-prod
   extraDashboardTags:
     - manage-recalls
     - prod


### PR DESCRIPTION
It looks like the YAML merge didn't go well, so I've just duplicated the
content from the `values-<env>.yaml` files into the new manage-recalls
ones.

Will clean this up as I go (and close of the deployments in
`ppud-replacement-<env>`.