### PR TITLE
PUD-1046: Fix `licenseRevocationDate` on recall notification document…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,9 @@ dependencyCheck {
   suppressionFiles.add("$rootDir/owasp.suppression.xml")
 }
 
+// Force log4j2.version to 2.17 for CVE-2021-45105
+project.extensions.extraProperties["log4j2.version"] = "2.17.0"
+
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-actuator:2.5.5")
   implementation("io.micrometer:micrometer-registry-prometheus:1.7.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/DocumentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/DocumentRepository.kt
@@ -30,6 +30,12 @@ interface JpaDocumentRepository : JpaRepository<Document, UUID> {
     @Param("recallId") recallId: UUID,
     @Param("category") category: DocumentCategory
   ): List<Document>
+
+  fun findByRecallIdAndCategoryAndVersion(
+    @Param("recallId") recallId: UUID,
+    @Param("category") category: DocumentCategory,
+    @Param("version") version: Int
+  ): Document?
 }
 
 @NoRepositoryBean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsGenerator.kt
@@ -26,7 +26,7 @@ class TableOfContentsGenerator(
       setVariable("bookingNumber", tableOfContentsContext.bookingNumber)
       setVariable("tableOfContentsItems", tableOfContentsItems)
       setVariable("category", "Not Applicable")
-      setVariable("version", "0")
+      setVariable("version", "0 (${tableOfContentsContext.newVersion})")
     }.let {
       templateEngine.process("table-of-contents", it)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallSummaryGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallSummaryGenerator.kt
@@ -23,8 +23,8 @@ class RecallSummaryGenerator(
 
   fun generateHtml(recallSummaryContext: RecallSummaryContext, recallNotificationTotalNumberOfPages: Int?): String =
     Context().apply {
-      setVariable("createdDate", recallSummaryContext.createdDateTime.toLocalDate().asStandardDateFormat())
-      setVariable("createdTime", recallSummaryContext.createdDateTime.asStandardTimeFormat())
+      setVariable("createdDate", recallSummaryContext.originalCreatedDateTime.toLocalDate().asStandardDateFormat())
+      setVariable("createdTime", recallSummaryContext.originalCreatedDateTime.asStandardTimeFormat())
       setVariable("recallNotificationTotalNumberOfPages", recallNotificationTotalNumberOfPages)
 
       setVariable("prisonerNameOnLicense", recallSummaryContext.prisonerNameOnLicense)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextTest.kt
@@ -44,7 +44,7 @@ class DossierContextTest {
 
   @Test
   fun `create ReasonsForRecallContext with all values correctly populated`() {
-    val underTest = DossierContext(recall, currentPrisonName, false)
+    val underTest = DossierContext(recall, currentPrisonName, false, 3)
 
     val result = underTest.getReasonsForRecallContext()
 
@@ -63,7 +63,7 @@ class DossierContextTest {
 
   @Test
   fun `create TableOfContentsContext with all values correctly populated`() {
-    val underTest = DossierContext(recall, currentPrisonName, false)
+    val underTest = DossierContext(recall, currentPrisonName, false, 3)
 
     val result = underTest.getTableOfContentsContext()
 
@@ -74,7 +74,8 @@ class DossierContextTest {
           PersonName(firstName, lastName = lastName).firstAndLastName(),
           RecallLengthDescription(recallLength),
           currentPrisonName,
-          bookingNumber
+          bookingNumber,
+          3
         )
       )
     )
@@ -91,7 +92,8 @@ class DossierContextTest {
     val underTest = DossierContext(
       recall.copy(probationInfo = probationInfo.copy(localDeliveryUnit = ldu)),
       currentPrisonName,
-      currentPrisonIsWelsh
+      currentPrisonIsWelsh,
+      2
     )
 
     assertThat(underTest.includeWelsh(), equalTo(expected))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsGeneratorTest.kt
@@ -52,7 +52,8 @@ class TableOfContentsGeneratorTest {
         FullName("Bertie Badger"),
         RecallLengthDescription(recallLength),
         currentPrisonName,
-        bookingNumber
+        bookingNumber,
+        2
       ),
       tableOfContentsItems
     )
@@ -71,7 +72,7 @@ class TableOfContentsGeneratorTest {
         has("currentPrisonName", { it.variableAsString("currentPrisonName") }, equalTo(currentPrisonName.value)),
         has("category", { it.variableAsString("category") }, equalTo("Not Applicable")),
         has("bookingNumber", { it.variableAsString("bookingNumber") }, equalTo(bookingNumber)),
-        has("version", { it.variableAsString("version") }, equalTo("0")),
+        has("version", { it.variableAsString("version") }, equalTo("0 (2)")),
         has("tableOfContentsItems", { it.variable("tableOfContentsItems") }, equalTo(tableOfContentsItems)),
       )
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsHtmlGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsHtmlGeneratorTest.kt
@@ -23,7 +23,8 @@ class TableOfContentsHtmlGeneratorTest(
         FullName("PrisonerFirstName PrisonerLastName"),
         RecallLengthDescription(TWENTY_EIGHT_DAYS),
         PrisonName("Current Prison (ABC)"),
-        "ABC1234F"
+        "ABC1234F",
+        2
       ),
       listOf(
         TableOfContentsItem("Document 1", 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextTest.kt
@@ -115,7 +115,7 @@ class RecallNotificationContextTest {
     lastReleasePrisonName,
     sentencingCourtName,
     localPoliceForceName,
-    fixedClock
+    OffsetDateTime.now(fixedClock)
   )
 
   @Test
@@ -168,7 +168,7 @@ class RecallNotificationContextTest {
       lastReleasePrisonName,
       sentencingCourtName,
       localPoliceForceName,
-      fixedClock
+      OffsetDateTime.now()
     )
 
     assertDoesNotThrow { underTest.getRevocationOrderContext() }
@@ -185,7 +185,7 @@ class RecallNotificationContextTest {
       lastReleasePrisonName,
       sentencingCourtName,
       localPoliceForceName,
-      fixedClock
+      OffsetDateTime.now()
     )
 
     assertDoesNotThrow { underTest.getRecallSummaryContext() }

--- a/src/test/resources/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsHtmlGeneratorTest_generate revocation order HTML.approved
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/TableOfContentsHtmlGeneratorTest_generate revocation order HTML.approved
@@ -115,7 +115,7 @@
       <th>
         VERSION:
       </th>
-      <td>0</td>
+      <td>0 (2)</td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
…s to be the date (and time) the document was first generated.

PUD-1047: Add document version in parentheses on the dossier table of contents