### PR TITLE
TECH: logback.version to 1.2.9 for CVE-2021-42550

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ dependencyCheck {
 
 // Force log4j2.version to 2.17 for CVE-2021-45105
 project.extensions.extraProperties["log4j2.version"] = "2.17.0"
+// Force logback.version to 1.2.9 (latest stable) for CVE-2021-42550
+project.extensions.extraProperties["logback.version"] = "1.2.9"
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-actuator:2.5.5")


### PR DESCRIPTION
TECH: logback.version to 1.2.9 for CVE-2021-42550
Passes `./gradlew dependencyCheckAnalyze --info` which is logged task for failing circle "Security" job  `hmpps/gradle_owasp_dependency_check`
Same job fails locally before this change, though this doesn't explain apparent repetition of same failure for `legacy-ppud-api`: https://mojdt.slack.com/archives/C0223AGGQU8/p1640281055036100?thread_ts=1640236006.020200&cid=C0223AGGQU8