### PR TITLE
PUD-1259  missing documents records BE: remove transitional API code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
@@ -48,18 +48,10 @@ class MissingDocumentsRecordController(
   )
   @PostMapping("/missing-documents-records")
   fun createMissingDocumentsRecord(
-    @RequestBody temp: TempMissingDocumentsRecordRequest,
+    @RequestBody missingDocumentsRecordRequest: MissingDocumentsRecordRequest,
     @RequestHeader("Authorization") bearerToken: String
-  ): ResponseEntity<MissingDocumentsRecordId> {
-    // TODO PUD-1259: remove use of temp request and class when UI has transitioned
-    val missingDocumentsRecordRequest = MissingDocumentsRecordRequest(
-      temp.recallId,
-      temp.categories,
-      temp.details ?: temp.detail!!,
-      temp.emailFileContent,
-      temp.emailFileName
-    )
-    return recallRepository.getByRecallId(missingDocumentsRecordRequest.recallId).let {
+  ): ResponseEntity<MissingDocumentsRecordId> =
+    recallRepository.getByRecallId(missingDocumentsRecordRequest.recallId).let {
       val currentUserId = tokenExtractor.getTokenFromHeader(bearerToken).userUuid()
       documentService.scanAndStoreDocument(
         missingDocumentsRecordRequest.recallId,
@@ -87,7 +79,6 @@ class MissingDocumentsRecordController(
         throw VirusFoundException()
       }
     }
-  }
 }
 
 data class MissingDocumentsRecordRequest(
@@ -96,13 +87,4 @@ data class MissingDocumentsRecordRequest(
   val details: String,
   val emailFileContent: String,
   val emailFileName: String
-)
-
-data class TempMissingDocumentsRecordRequest(
-  val recallId: RecallId,
-  val categories: List<DocumentCategory>,
-  val details: String?,
-  val emailFileContent: String,
-  val emailFileName: String,
-  val detail: String?,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AuthenticatedClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AuthenticatedClient.kt
@@ -17,12 +17,12 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.FieldAuditEntry
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.FieldAuditSummary
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.GenerateDocumentRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.GetDocumentResponse
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.MissingDocumentsRecordRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.NewDocumentResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallSearchRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.SearchRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.SearchResult
-import uk.gov.justice.digital.hmpps.managerecallsapi.controller.TempMissingDocumentsRecordRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.UpdateDocumentRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.UpdateDocumentResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.UpdateRecallRequest
@@ -131,7 +131,7 @@ class AuthenticatedClient(
     deleteRequest("/recalls/$recallId/assignee/$assignee", expectedStatus)
 
   fun <T> missingDocumentsRecord(
-    request: TempMissingDocumentsRecordRequest,
+    request: MissingDocumentsRecordRequest,
     expectedStatus: HttpStatus = CREATED,
     responseClass: Class<T>
   ) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
@@ -68,10 +68,9 @@ class MissingDocumentsRecordControllerTest {
     every { record.id() } returns missingDocumentsRecordId
 
     val details = "blah blah"
-    val request = TempMissingDocumentsRecordRequest(
+    val request = MissingDocumentsRecordRequest(
       recallId, listOf(DocumentCategory.PART_A_RECALL_REPORT), details,
-      documentBytes.encodeToBase64String(), fileName,
-      "old detail ignored as details is non-null"
+      documentBytes.encodeToBase64String(), fileName
     )
 
     val response = underTest.createMissingDocumentsRecord(request, bearerToken)
@@ -118,17 +117,14 @@ class MissingDocumentsRecordControllerTest {
     every { missingDocumentsRecordRepository.save(capture(savedMissingDocumentsRecord)) } returns record
     every { record.id() } returns missingDocumentsRecordId
 
-    val detail = "original detail prop"
-    val request = TempMissingDocumentsRecordRequest(
-      recallId, listOf(DocumentCategory.PART_A_RECALL_REPORT), null,
-      documentBytes.encodeToBase64String(), fileName,
-      detail
+    val request = MissingDocumentsRecordRequest(
+      recallId, listOf(DocumentCategory.PART_A_RECALL_REPORT), "detail",
+      documentBytes.encodeToBase64String(), fileName
     )
 
     val response = underTest.createMissingDocumentsRecord(request, bearerToken)
 
     assertThat(savedMissingDocumentsRecord.captured.version, equalTo(2))
-    assertThat(savedMissingDocumentsRecord.captured.details, equalTo(detail))
     assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
     assertThat(
       response.body,


### PR DESCRIPTION
PUD-1259  missing documents records BE: remove transitional API code now that UI change is complete
FYI I'm still looking at improving the PACT in this area, e.g. given that the UI contract "expected" `emailFileName` in the MDR when it for certain was not present.