### PR TITLE
PUD-1282  API: document detail to be non-blank for version gt 1

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
@@ -58,7 +58,8 @@ class MissingDocumentsRecordController(
         currentUserId,
         missingDocumentsRecordRequest.emailFileContent.toBase64DecodedByteArray(),
         DocumentCategory.MISSING_DOCUMENTS_EMAIL,
-        missingDocumentsRecordRequest.emailFileName
+        missingDocumentsRecordRequest.emailFileName,
+        missingDocumentsRecordRequest.details
       ).map { documentId ->
         val currentVersion = it.missingDocumentsRecords.maxByOrNull { it.version }?.version ?: 0
         val mdr = missingDocumentsRecordRepository.save(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
@@ -59,7 +59,7 @@ class MissingDocumentsRecordController(
         missingDocumentsRecordRequest.emailFileContent.toBase64DecodedByteArray(),
         DocumentCategory.MISSING_DOCUMENTS_EMAIL,
         missingDocumentsRecordRequest.emailFileName,
-        missingDocumentsRecordRequest.details
+        missingDocumentsRecordRequest.details // The MDR "details" are stored twice - see below - for ease of use: its needed here to avoid PUD-1251
       ).map { documentId ->
         val currentVersion = it.missingDocumentsRecords.maxByOrNull { it.version }?.version ?: 0
         val mdr = missingDocumentsRecordRepository.save(

--- a/src/main/resources/db/migration/V68__Non_blank_details_for_document_version_gt_one.sql
+++ b/src/main/resources/db/migration/V68__Non_blank_details_for_document_version_gt_one.sql
@@ -1,0 +1,6 @@
+-- Allow blank document details only when version is null or 1
+ALTER TABLE document ADD CONSTRAINT details_not_blank_constraint_for_version_gt_1
+    CHECK ((version IS NULL) OR
+           (version = 1) OR
+           (details IS NOT NULL AND TRIM(details) <> ''));
+);

--- a/src/main/resources/db/migration/V68__Non_blank_details_for_document_version_gt_one.sql
+++ b/src/main/resources/db/migration/V68__Non_blank_details_for_document_version_gt_one.sql
@@ -3,4 +3,8 @@ ALTER TABLE document ADD CONSTRAINT details_not_blank_constraint_for_version_gt_
     CHECK ((version IS NULL) OR
            (version = 1) OR
            (details IS NOT NULL AND TRIM(details) <> ''));
-);
+
+-- Restrict valid values of version: null or positive: type is integer but there is no unsigned integer type
+ALTER TABLE document ADD CONSTRAINT version_null_or_positive_integer
+    CHECK ((version IS NULL) OR
+           (version >= 1));

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.managerecallsapi.component
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.present
+import com.natpryce.hamkrest.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.NOT_FOUND
@@ -82,7 +83,7 @@ class DocumentComponentTest : ComponentTestBase() {
       .expectBody(ErrorResponse::class.java).returnResult().responseBody!!
 
     assertThat(result.status, equalTo(BAD_REQUEST))
-    assertThat(result.message.toString().substring(0, 29), equalTo("IllegalDocumentStateException"))
+    assertThat(result.message!!, startsWith("IllegalDocumentStateException"))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
@@ -69,6 +69,23 @@ class DocumentComponentTest : ComponentTestBase() {
   }
 
   @Test
+  fun `add a versioned document at version 2 with blank details returns bad request with body`() {
+    expectNoVirusesWillBeFound()
+
+    val recall = authenticatedClient.bookRecall(bookRecallRequest)
+
+    val response = authenticatedClient.uploadDocument(recall.recallId, addVersionedDocumentRequest)
+
+    assertThat(response.documentId, present())
+
+    val result = authenticatedClient.uploadDocument(recall.recallId, addVersionedDocumentRequest.copy(details = " "), BAD_REQUEST)
+      .expectBody(ErrorResponse::class.java).returnResult().responseBody!!
+
+    assertThat(result.status, equalTo(BAD_REQUEST))
+    assertThat(result.message.toString().substring(0, 29), equalTo("IllegalDocumentStateException"))
+  }
+
+  @Test
   fun `upload multiple documents with a 'versioned' category that already exists writes a new document and increments version`() {
     expectNoVirusesWillBeFound()
 
@@ -382,19 +399,19 @@ class DocumentComponentTest : ComponentTestBase() {
     val category = PART_A_RECALL_REPORT
     authenticatedClient.uploadDocument(
       recall.recallId,
-      UploadDocumentRequest(category, base64EncodedDocumentContents, fileName)
+      UploadDocumentRequest(category, base64EncodedDocumentContents, fileName, null)
     )
     authenticatedClient.uploadDocument(
       recall.recallId,
-      UploadDocumentRequest(category, base64EncodedDocumentContents, fileName)
+      UploadDocumentRequest(category, base64EncodedDocumentContents, fileName, details)
     )
     authenticatedClient.uploadDocument(
       recall.recallId,
-      UploadDocumentRequest(category, base64EncodedDocumentContents, fileName)
+      UploadDocumentRequest(category, base64EncodedDocumentContents, fileName, details)
     )
     authenticatedClient.uploadDocument(
       recall.recallId,
-      UploadDocumentRequest(LICENCE, base64EncodedDocumentContents, fileName)
+      UploadDocumentRequest(LICENCE, base64EncodedDocumentContents, fileName, null)
     )
     val recallDocuments = authenticatedClient.getRecallDocuments(recall.recallId, category)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/MissingDocumentsRecordComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/MissingDocumentsRecordComponentTest.kt
@@ -70,11 +70,12 @@ class MissingDocumentsRecordComponentTest : ComponentTestBase() {
 
     val recallWithMissingDocumentsRecord = authenticatedClient.getRecall(recall.recallId)
     assertThat(recall.missingDocumentsRecords, isEmpty)
-    assertThat(recallWithMissingDocumentsRecord.missingDocumentsRecords.size, equalTo(2))
-    assertThat(recallWithMissingDocumentsRecord.missingDocumentsRecords[0].version, !equalTo(recallWithMissingDocumentsRecord.missingDocumentsRecords[1].version))
-    // TODO: following are unstable with the order of the returned records being non-deterministic when presumably we do want them to be
-    // assertThat(recallWithMissingDocumentsRecord.missingDocumentsRecords[0].details, equalTo(detailsMostRecent))
-    // assertThat(recallWithMissingDocumentsRecord.missingDocumentsRecords[1].details, equalTo(detailsOldest))
+    val missingDocumentsRecords = recallWithMissingDocumentsRecord.missingDocumentsRecords
+    assertThat(missingDocumentsRecords.size, equalTo(2))
+    assertThat(missingDocumentsRecords[0].version, !equalTo(missingDocumentsRecords[1].version))
+    // There is no contract for the order of MDRs but the versions must be one-based incrementing positive integers, hence 1, 2, etc.
+    assertThat(missingDocumentsRecords[missingDocumentsRecords.indexOfFirst { it.version == 2 }].details, equalTo(detailsMostRecent))
+    assertThat(missingDocumentsRecords[missingDocumentsRecords.indexOfFirst { it.version == 1 }].details, equalTo(detailsOldest))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
@@ -51,6 +51,7 @@ class MissingDocumentsRecordControllerTest {
     val bearerToken = "BEARER TOKEN"
     val userId = ::UserId.random()
     val missingDocumentsRecordId = ::MissingDocumentsRecordId.random()
+    val details = "blah blah"
 
     every { recall.missingDocumentsRecords } returns emptySet()
     every { recallRepository.getByRecallId(recallId) } returns recall
@@ -60,14 +61,14 @@ class MissingDocumentsRecordControllerTest {
         userId,
         documentBytes,
         DocumentCategory.MISSING_DOCUMENTS_EMAIL,
-        fileName
+        fileName,
+        details
       )
     } returns Success(emailId)
     every { tokenExtractor.getTokenFromHeader(bearerToken) } returns TokenExtractor.Token(userId.toString())
     every { missingDocumentsRecordRepository.save(capture(savedMissingDocumentsRecord)) } returns record
     every { record.id() } returns missingDocumentsRecordId
 
-    val details = "blah blah"
     val request = MissingDocumentsRecordRequest(
       recallId, listOf(DocumentCategory.PART_A_RECALL_REPORT), details,
       documentBytes.encodeToBase64String(), fileName
@@ -98,6 +99,7 @@ class MissingDocumentsRecordControllerTest {
     val userId = ::UserId.random()
     val missingDocumentsRecordId = ::MissingDocumentsRecordId.random()
     val fullName = FullName("Harry Potter")
+    val details = "detail"
 
     val existingRecord = mockk<MissingDocumentsRecord>()
     every { recall.missingDocumentsRecords } returns setOf(existingRecord)
@@ -110,7 +112,8 @@ class MissingDocumentsRecordControllerTest {
         userId,
         documentBytes,
         DocumentCategory.MISSING_DOCUMENTS_EMAIL,
-        fileName
+        fileName,
+        details
       )
     } returns Success(emailId)
     every { tokenExtractor.getTokenFromHeader(bearerToken) } returns TokenExtractor.Token(userId.toString())
@@ -118,7 +121,7 @@ class MissingDocumentsRecordControllerTest {
     every { record.id() } returns missingDocumentsRecordId
 
     val request = MissingDocumentsRecordRequest(
-      recallId, listOf(DocumentCategory.PART_A_RECALL_REPORT), "detail",
+      recallId, listOf(DocumentCategory.PART_A_RECALL_REPORT), details,
       documentBytes.encodeToBase64String(), fileName
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/DocumentRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/DocumentRepositoryIntegrationTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.managerecallsapi.integration.db
 import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.startsWith
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -99,7 +100,7 @@ class DocumentRepositoryIntegrationTest(
 
   @Test
   @Transactional
-  fun `can save and flush two distinct copies of a versioned document with different versions for an existing recall`() {
+  fun `can save and flush two distinct copies of a versioned document with different valid versions for an existing recall`() {
     recallRepository.save(recall, currentUserId)
 
     val idOne = ::DocumentId.random()
@@ -114,6 +115,34 @@ class DocumentRepositoryIntegrationTest(
 
     assertThat(retrievedOne, equalTo(docOne))
     assertThat(retrievedTwo, equalTo(docTwo))
+  }
+
+  @Test
+  @Transactional
+  fun `cannot save and flush version 0 of a versioned document throws DataIntegrityViolationException`() {
+    recallRepository.save(recall, currentUserId)
+
+    val id = ::DocumentId.random()
+    val documentWithBlankDetails = versionedDocument(id, recallId, versionedCategory, 0)
+
+    val thrown = assertThrows<DataIntegrityViolationException> {
+      documentRepository.saveAndFlush(documentWithBlankDetails)
+    }
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
+  }
+
+  @Test
+  @Transactional
+  fun `cannot save and flush version -1 of a versioned document throws DataIntegrityViolationException`() {
+    recallRepository.save(recall, currentUserId)
+
+    val id = ::DocumentId.random()
+    val documentWithBlankDetails = versionedDocument(id, recallId, versionedCategory, -1)
+
+    val thrown = assertThrows<DataIntegrityViolationException> {
+      documentRepository.saveAndFlush(documentWithBlankDetails)
+    }
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
   }
 
   @Test
@@ -173,7 +202,7 @@ class DocumentRepositoryIntegrationTest(
     val thrown = assertThrows<DataIntegrityViolationException> {
       documentRepository.saveAndFlush(docTwo)
     }
-    assertThat(thrown.message!!.substring(0, 27), equalTo("could not execute statement"))
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
   }
 
   @Test
@@ -187,7 +216,7 @@ class DocumentRepositoryIntegrationTest(
     val thrown = assertThrows<DataIntegrityViolationException> {
       documentRepository.saveAndFlush(document)
     }
-    assertThat(thrown.message!!.substring(0, 27), equalTo("could not execute statement"))
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
   }
 
   @Test
@@ -232,7 +261,7 @@ class DocumentRepositoryIntegrationTest(
     val thrown = assertThrows<DataIntegrityViolationException> {
       documentRepository.saveAndFlush(documentWithBlankDetails)
     }
-    assertThat(thrown.message!!.substring(0, 27), equalTo("could not execute statement"))
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
   }
 
   @Test
@@ -246,7 +275,7 @@ class DocumentRepositoryIntegrationTest(
     val thrown = assertThrows<DataIntegrityViolationException> {
       documentRepository.saveAndFlush(document)
     }
-    assertThat(thrown.message!!.substring(0, 27), equalTo("could not execute statement"))
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/MissingDocumentsRecordRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/MissingDocumentsRecordRepositoryIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.managerecallsapi.integration.db
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.startsWith
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -132,6 +133,6 @@ class MissingDocumentsRecordRepositoryIntegrationTest(
     val thrown = assertThrows<DataIntegrityViolationException> {
       missingDocumentsRecordRepository.saveAndFlush(mdrTwo)
     }
-    assertThat(thrown.message!!.substring(0, 27), equalTo("could not execute statement"))
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/random/RandomUtilities.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/random/RandomUtilities.kt
@@ -39,7 +39,7 @@ internal fun fullyPopulatedRecall(recallId: RecallId = ::RecallId.random(), know
         document.copy(
           recallId = recallId.value,
           // ensure document version is valid versus category
-          version = if (document.category.versioned) Random.nextInt() else null,
+          version = if (document.category.versioned) Random.nextInt(1, Int.MAX_VALUE) else null,
           createdByUserId = (knownUserId ?: ::UserId.random()).value
         )
       }.toSet(),
@@ -47,6 +47,7 @@ internal fun fullyPopulatedRecall(recallId: RecallId = ::RecallId.random(), know
         mdr.copy(
           recallId = recallId.value,
           emailId = recall.documents.random().id,
+          version = Random.nextInt(1, Int.MAX_VALUE),
           createdByUserId = (knownUserId ?: ::UserId.random()).value
         )
       }.toSet()


### PR DESCRIPTION
API: require generated document detail to be non-blank for all document versions except the first, version 1