### PR TITLE
PUD-1319  API: Support last known addresses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/RestConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/RestConfiguration.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldPath
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MiddleNames
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MissingDocumentsRecordId
@@ -84,6 +85,7 @@ private fun AutoMappingConfiguration<ObjectMapper>.withCustomMappings() = apply 
   text(::FieldPath)
   text(StringBiDiMappings.uuid().map(::RecallId, RecallId::value))
   text(StringBiDiMappings.uuid().map(::MissingDocumentsRecordId, MissingDocumentsRecordId::value))
+  text(StringBiDiMappings.uuid().map(::LastKnownAddressId, LastKnownAddressId::value))
   text(StringBiDiMappings.uuid().map(::DocumentId, DocumentId::value))
   text(StringBiDiMappings.uuid().map(::UserId, UserId::value))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/SpringFoxConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/SpringFoxConfig.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldPath
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MiddleNames
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MissingDocumentsRecordId
@@ -71,6 +72,7 @@ class SpringFoxConfig {
       .directModelSubstitute(RecallId::class.java, UUID::class.java)
       .directModelSubstitute(DocumentId::class.java, UUID::class.java)
       .directModelSubstitute(MissingDocumentsRecordId::class.java, UUID::class.java)
+      .directModelSubstitute(LastKnownAddressId::class.java, UUID::class.java)
       .directModelSubstitute(UserId::class.java, UUID::class.java)
       .directModelSubstitute(PrisonId::class.java, String::class.java)
       .directModelSubstitute(PrisonName::class.java, String::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressController.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.controller
+
+import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
+import io.swagger.annotations.Example
+import io.swagger.annotations.ExampleProperty
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.managerecallsapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.extractor.TokenExtractor
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddress
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddressRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+import java.time.OffsetDateTime
+
+@RestController
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+@PreAuthorize("hasRole('ROLE_MANAGE_RECALLS')")
+class LastKnownAddressController(
+  @Autowired private val recallRepository: RecallRepository,
+  @Autowired private val lastKnownAddressRepository: LastKnownAddressRepository,
+  @Autowired private val tokenExtractor: TokenExtractor
+) {
+
+  @ApiResponses(
+    ApiResponse(
+      code = 404, message = "RecallNotFoundException(recallId=...)", response = ErrorResponse::class,
+      examples = Example(ExampleProperty(mediaType = "application/json", value = "{\n\"status\": 404,\n\"message\":\"RecallNotFoundException(recallId=...)\"\n}"))
+    )
+  )
+  @PostMapping("/last-known-addresses")
+  fun createLastKnownAddress(
+    @RequestBody request: CreateLastKnownAddressRequest,
+    @RequestHeader("Authorization") bearerToken: String
+  ): ResponseEntity<LastKnownAddressId> =
+    recallRepository.getByRecallId(request.recallId).let { recall ->
+      val currentUserId = tokenExtractor.getTokenFromHeader(bearerToken).userUuid()
+      val previousIndex = recall.lastKnownAddresses.maxByOrNull { it.index }?.index ?: 0
+      val saved = lastKnownAddressRepository.save(
+        LastKnownAddress(
+          ::LastKnownAddressId.random(),
+          request.recallId,
+          request.line1,
+          request.line2,
+          request.town,
+          request.postcode,
+          request.source,
+          previousIndex + 1,
+          currentUserId,
+          OffsetDateTime.now()
+        )
+      )
+      ResponseEntity(saved.id(), HttpStatus.CREATED)
+    }
+}
+
+data class CreateLastKnownAddressRequest(
+  val recallId: RecallId,
+  val line1: String,
+  val line2: String?,
+  val town: String,
+  val postcode: String?,
+  val source: AddressSource,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallController.kt
@@ -15,11 +15,13 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.extractor.TokenExtractor
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand.FOUR_PLUS
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand.THREE
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Document
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddress
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.MissingDocumentsRecord
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
@@ -28,6 +30,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MiddleNames
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MissingDocumentsRecordId
@@ -141,6 +144,7 @@ class RecallController(
     status = this.status(),
     documents = latestDocuments(documents),
     missingDocumentsRecords = missingDocumentsRecords.map { record -> record.toResponse() },
+    lastKnownAddresses = lastKnownAddresses.map { address -> address.toResponse() },
     recallLength = this.recallLength,
     lastReleasePrison = this.lastReleasePrison,
     lastReleaseDate = this.lastReleaseDate,
@@ -228,6 +232,18 @@ class RecallController(
     userDetailsService.get(this.createdByUserId()).fullName(),
     this.createdDateTime
   )
+
+  fun LastKnownAddress.toResponse() = Api.LastKnownAddress(
+    this.id(),
+    this.line1,
+    this.line2,
+    this.town,
+    this.postcode,
+    this.source,
+    this.index,
+    userDetailsService.get(this.createdByUserId()).fullName(),
+    this.createdDateTime
+  )
 }
 
 fun BookRecallRequest.toRecall(userUuid: UserId): Recall {
@@ -263,6 +279,7 @@ data class RecallResponse(
   val status: Status,
   val documents: List<Api.RecallDocument> = emptyList(),
   val missingDocumentsRecords: List<Api.MissingDocumentsRecord> = emptyList(),
+  val lastKnownAddresses: List<Api.LastKnownAddress> = emptyList(),
   val recallLength: RecallLength? = null,
   val lastReleasePrison: PrisonId? = null,
   val lastReleaseDate: LocalDate? = null,
@@ -339,6 +356,18 @@ class Api {
     val emailFileName: String,
     val details: String,
     val version: Int,
+    val createdByUserName: FullName,
+    val createdDateTime: OffsetDateTime
+  )
+
+  data class LastKnownAddress(
+    val lastKnownAddressId: LastKnownAddressId,
+    val line1: String,
+    val line2: String?,
+    val town: String,
+    val postcode: String?,
+    val source: AddressSource,
+    val index: Int,
     val createdByUserName: FullName,
     val createdDateTime: OffsetDateTime
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/LastKnownAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/LastKnownAddress.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.db
+
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType.STRING
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.Table
+
+enum class AddressSource {
+  MANUAL,
+  LOOKUP,
+}
+
+@Entity
+@Table(name = "last_known_address")
+data class LastKnownAddress(
+  @Id
+  val id: UUID,
+
+  @Column(name = "recall_id", nullable = false)
+  val recallId: UUID,
+
+  @Column(nullable = false)
+  val line1: String,
+
+  @Column(nullable = true)
+  val line2: String?,
+
+  @Column(nullable = true)
+  val town: String,
+
+  @Column(nullable = false)
+  val postcode: String?,
+
+  @Enumerated(STRING)
+  @Column(nullable = false)
+  val source: AddressSource,
+
+  @Column(nullable = false)
+  val index: Int,
+
+  @Column(nullable = false)
+  val createdByUserId: UUID,
+
+  @Column(nullable = false)
+  val createdDateTime: OffsetDateTime
+) {
+  constructor(
+    id: LastKnownAddressId,
+    recallId: RecallId,
+    line1: String,
+    line2: String?,
+    town: String,
+    postcode: String?,
+    source: AddressSource,
+    index: Int,
+    createdByUserId: UserId,
+    createdDateTime: OffsetDateTime
+  ) :
+    this(
+      id.value, recallId.value, line1, line2, town, postcode, source, index, createdByUserId.value, createdDateTime
+    )
+
+  fun id() = LastKnownAddressId(id)
+  fun recallId() = RecallId(recallId)
+  fun createdByUserId() = UserId(createdByUserId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/LastKnownAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/LastKnownAddressRepository.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.db
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.NoRepositoryBean
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository("jpaLastKnownAddressRepository")
+interface JpaLastKnownAddressRepository : JpaRepository<LastKnownAddress, UUID>
+
+@NoRepositoryBean
+interface ExtendedLastKnownAddressRepository : JpaLastKnownAddressRepository
+
+@Component
+class LastKnownAddressRepository(
+  @Qualifier("jpaLastKnownAddressRepository") @Autowired private val jpaRepository: JpaLastKnownAddressRepository
+) : JpaLastKnownAddressRepository by jpaRepository, ExtendedLastKnownAddressRepository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Recall.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Recall.kt
@@ -73,6 +73,9 @@ data class Recall(
   @OneToMany(cascade = [ALL])
   @JoinColumn(name = "recall_id")
   val missingDocumentsRecords: Set<MissingDocumentsRecord> = emptySet(),
+  @OneToMany(cascade = [ALL])
+  @JoinColumn(name = "recall_id")
+  val lastKnownAddresses: Set<LastKnownAddress> = emptySet(),
   @Enumerated(STRING)
   val recallType: RecallType? = null,
   @Enumerated(STRING)
@@ -139,6 +142,7 @@ data class Recall(
     lastUpdatedDateTime: OffsetDateTime = createdDateTime,
     documents: Set<Document> = emptySet(),
     missingDocumentsRecords: Set<MissingDocumentsRecord> = emptySet(),
+    lastKnownAddresses: Set<LastKnownAddress> = emptySet(),
     recallType: RecallType? = null,
     recallLength: RecallLength? = null,
     lastReleasePrison: PrisonId? = null,
@@ -191,6 +195,7 @@ data class Recall(
       licenceNameCategory,
       documents,
       missingDocumentsRecords,
+      lastKnownAddresses,
       recallType,
       recallLength,
       lastReleasePrison,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/domain/domain.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/domain/domain.kt
@@ -17,6 +17,7 @@ class NomsNumber(value: String) : Validated<String>(value, notBlank, alphanumeri
 class RecallId(value: UUID) : Validated<UUID>(value)
 class DocumentId(value: UUID) : Validated<UUID>(value)
 class MissingDocumentsRecordId(value: UUID) : Validated<UUID>(value)
+class LastKnownAddressId(value: UUID) : Validated<UUID>(value)
 class UserId(value: UUID) : Validated<UUID>(value)
 class FirstName(value: String) : Validated<String>(value, notBlank)
 class MiddleNames(value: String) : Validated<String>(value, notBlank)

--- a/src/main/resources/db/migration/V73__Add_last_known_addresses_table.sql
+++ b/src/main/resources/db/migration/V73__Add_last_known_addresses_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE last_known_address (
+          id UUID PRIMARY KEY,
+          recall_id UUID NOT NULL REFERENCES recall (id),
+          line1 TEXT NOT NULL,
+          line2 TEXT NULL,
+          town TEXT NOT NULL,
+          postcode TEXT NULL,
+          source TEXT NOT NULL,
+          index INTEGER NOT NULL,
+          created_by_user_id UUID references user_details(id),
+          created_date_time TIMESTAMPTZ NOT NULL,
+          UNIQUE (recall_id, index),
+          CONSTRAINT index_positive_integer CHECK (index >= 1)
+);
+
+-- DROP TABLE last_known_address;

--- a/src/main/resources/db/migration/V73__Add_last_known_addresses_table.sql
+++ b/src/main/resources/db/migration/V73__Add_last_known_addresses_table.sql
@@ -7,10 +7,9 @@ CREATE TABLE last_known_address (
           postcode TEXT NULL,
           source TEXT NOT NULL,
           index INTEGER NOT NULL,
-          created_by_user_id UUID references user_details(id),
+          created_by_user_id UUID NOT NULL references user_details(id),
           created_date_time TIMESTAMPTZ NOT NULL,
           UNIQUE (recall_id, index),
+          CONSTRAINT source_in_enum CHECK (source IN ('MANUAL','LOOKUP')),
           CONSTRAINT index_positive_integer CHECK (index >= 1)
 );
-
--- DROP TABLE last_known_address;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AuthenticatedClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AuthenticatedClient.kt
@@ -13,6 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.AddUserDetailsRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Api
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.CreateLastKnownAddressRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.FieldAuditEntry
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.FieldAuditSummary
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.GenerateDocumentRequest
@@ -137,6 +138,13 @@ class AuthenticatedClient(
     responseClass: Class<T>
   ) =
     postRequest("/missing-documents-records", request, responseClass, expectedStatus)
+
+  fun <T> lastKnownAddress(
+    request: CreateLastKnownAddressRequest,
+    expectedStatus: HttpStatus = CREATED,
+    responseClass: Class<T>
+  ) =
+    postRequest("/last-known-addresses", request, responseClass, expectedStatus)
 
   fun search(searchRequest: SearchRequest, expectedStatus: HttpStatus) =
     sendPostRequest("/search", searchRequest, expectedStatus)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/ComponentTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/ComponentTestBase.kt
@@ -21,6 +21,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddressRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.MissingDocumentsRecordRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallAuditRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallReasonAuditRepository
@@ -81,6 +82,9 @@ abstract class ComponentTestBase(private val useRealGotenbergServer: Boolean = f
 
   @Autowired
   protected lateinit var missingDocumentsRecordRepository: MissingDocumentsRecordRepository
+
+  @Autowired
+  protected lateinit var lastKnownAddressRepository: LastKnownAddressRepository
 
   @Autowired
   protected lateinit var prisonerOffenderSearchMockServer: PrisonerOffenderSearchMockServer

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
@@ -6,6 +6,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient.RequestBodySpec
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.AddUserDetailsRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.CreateLastKnownAddressRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.GenerateDocumentRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.MissingDocumentsRecordRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallSearchRequest
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.SearchRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.UpdateDocumentRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.UpdateRecallRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.UploadDocumentRequest
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.encodeToBase64String
@@ -50,6 +52,7 @@ class EndpointSecurityComponentTest : ComponentTestBase() {
   private val updateDocumentRequest = UpdateDocumentRequest(DocumentCategory.values().random())
   private val generateDocumentRequest = GenerateDocumentRequest(DocumentCategory.RECALL_NOTIFICATION, "some more detail")
   private val missingDocumentsRecordRequest = MissingDocumentsRecordRequest(::RecallId.random(), listOf(DocumentCategory.values().random()), "some detail", "content", "email.msg")
+  private val createLastKnownAddressRequest = CreateLastKnownAddressRequest(::RecallId.random(), "address line 1", "address line 2", "some town", "some postcode", AddressSource.LOOKUP)
 
   // TODO:  MD get all the secured endpoints and make sure they are all included here (or get them all and automagically create the requests?)
   // Can this be a more lightweight test?  i.e. something other than a SpringBootTest. WebMVC test?
@@ -75,6 +78,7 @@ class EndpointSecurityComponentTest : ComponentTestBase() {
       webTestClient.post().uri("/recalls/${UUID.randomUUID()}/assignee/${::UserId.random()}"),
       webTestClient.post().uri("/users/").bodyValue(userDetailsRequest),
       webTestClient.post().uri("/missing-documents-records").bodyValue(missingDocumentsRecordRequest),
+      webTestClient.post().uri("/last-known-addresses").bodyValue(createLastKnownAddressRequest),
       webTestClient.delete().uri("/recalls/${UUID.randomUUID()}/assignee/${::UserId.random()}"),
       webTestClient.delete().uri("/recalls/${UUID.randomUUID()}/documents/${::DocumentId.random()}")
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallComponentTest.kt
@@ -72,6 +72,8 @@ class GetRecallComponentTest : ComponentTestBase() {
     recallRepository.save(fullyPopulatedRecall, createdByUserId)
 
     val missingDocumentsRecord = fullyPopulatedRecall.missingDocumentsRecords.first()
+    val lastKnownAddress = fullyPopulatedRecall.lastKnownAddresses.first()
+
     // TODO:  MD Fix assertions, or move somewhere more sensible.
     authenticatedClient.get("/recalls/$recallId")
       .expectBody()
@@ -93,6 +95,16 @@ class GetRecallComponentTest : ComponentTestBase() {
       .jsonPath("$.missingDocumentsRecords[0].emailId").isEqualTo(missingDocumentsRecord.emailId.toString())
       .jsonPath("$.missingDocumentsRecords[0].createdByUserName").isEqualTo("Bertie Badger")
       .jsonPath("$.missingDocumentsRecords[0].createdDateTime").value(endsWith("Z"))
+      .jsonPath("$.lastKnownAddresses.length()").isEqualTo(1)
+      .jsonPath("$.lastKnownAddresses[0].lastKnownAddressId").isEqualTo(lastKnownAddress.id.toString())
+      .jsonPath("$.lastKnownAddresses[0].line1").isEqualTo(lastKnownAddress.line1)
+      .jsonPath("$.lastKnownAddresses[0].line2").isEqualTo(lastKnownAddress.line2!!)
+      .jsonPath("$.lastKnownAddresses[0].town").isEqualTo(lastKnownAddress.town)
+      .jsonPath("$.lastKnownAddresses[0].postcode").isEqualTo(lastKnownAddress.postcode!!)
+      .jsonPath("$.lastKnownAddresses[0].index").isEqualTo(lastKnownAddress.index)
+      .jsonPath("$.lastKnownAddresses[0].source").isEqualTo(lastKnownAddress.source.name)
+      .jsonPath("$.lastKnownAddresses[0].createdByUserName").isEqualTo("Bertie Badger")
+      .jsonPath("$.lastKnownAddresses[0].createdDateTime").value(endsWith("Z"))
       .jsonPath("$.recallLength").isEqualTo(fullyPopulatedRecall.recallLength!!.name)
       .jsonPath("$.lastReleasePrison").isEqualTo(fullyPopulatedRecall.lastReleasePrison!!.value)
       .jsonPath("$.recallEmailReceivedDateTime").value(endsWith("Z"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.component
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.isEmpty
+import com.natpryce.hamkrest.present
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.CREATED
+import uk.gov.justice.digital.hmpps.managerecallsapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.CreateLastKnownAddressRequest
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+
+class LastKnownAddressComponentTest : ComponentTestBase() {
+  private val nomsNumber = NomsNumber("123456")
+  private val bookRecallRequest = BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger"))
+
+  @Test
+  fun `create and retrieve one LastKnownAddress for a recall`() {
+    val originalRecall = authenticatedClient.bookRecall(bookRecallRequest)
+    val createLastKnownAddressRequest = CreateLastKnownAddressRequest(
+      originalRecall.recallId,
+      "address line 1",
+      "some line 2",
+      "some town",
+      "the postcode",
+      AddressSource.MANUAL
+    )
+
+    val lastKnownAddressId = authenticatedClient.lastKnownAddress(createLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
+    assertThat(lastKnownAddressId, present())
+
+    val updatedRecall = authenticatedClient.getRecall(originalRecall.recallId)
+    assertThat(originalRecall.lastKnownAddresses, isEmpty)
+
+    val lastKnownAddresses = updatedRecall.lastKnownAddresses
+    assertThat(lastKnownAddresses.size, equalTo(1))
+    assertThat(lastKnownAddresses.first().line1, equalTo("address line 1"))
+    assertThat(lastKnownAddresses.first().line2, equalTo("some line 2"))
+    assertThat(lastKnownAddresses.first().town, equalTo("some town"))
+    assertThat(lastKnownAddresses.first().postcode, equalTo("the postcode"))
+    assertThat(lastKnownAddresses.first().index, equalTo(1))
+    assertThat(lastKnownAddresses.first().source.toString(), equalTo("MANUAL"))
+    assertThat(lastKnownAddresses.first().lastKnownAddressId.toString(), equalTo(lastKnownAddressId.value.toString()))
+  }
+
+  @Test
+  fun `adding 2 LastKnownAddresses for the same recall, optional properties can be null, both will be returned on the recall with incrementing index`() {
+    val originalRecall = authenticatedClient.bookRecall(bookRecallRequest)
+    val firstLastKnownAddressRequest = CreateLastKnownAddressRequest(
+      originalRecall.recallId,
+      "address line 1",
+      "some line 2",
+      "first town",
+      "the postcode",
+      AddressSource.LOOKUP
+    )
+
+    val lastKnownAddressId1 = authenticatedClient.lastKnownAddress(firstLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
+    assertThat(lastKnownAddressId1, present())
+
+    val secondLastKnownAddressRequest = firstLastKnownAddressRequest.copy(
+      line2 = null,
+      town = "second town",
+      postcode = null,
+      source = AddressSource.MANUAL
+    )
+    val lastKnownAddressId2 = authenticatedClient.lastKnownAddress(secondLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
+    assertThat(lastKnownAddressId2, present())
+    assertThat(lastKnownAddressId1, !equalTo(lastKnownAddressId2))
+
+    val updatedRecall = authenticatedClient.getRecall(originalRecall.recallId)
+    assertThat(originalRecall.lastKnownAddresses, isEmpty)
+
+    val lastKnownAddresses = updatedRecall.lastKnownAddresses
+    assertThat(lastKnownAddresses.size, equalTo(2))
+
+    assertThat(lastKnownAddresses[0].index, !equalTo(lastKnownAddresses[1].index))
+    // There is no contract for the order of LastKnownAddresses but the index must be one-based incrementing positive integers, hence 1, 2, etc.
+    val lastKnownAddressIndex1 = lastKnownAddresses[lastKnownAddresses.indexOfFirst { it.index == 1 }]
+    val lastKnownAddressIndex2 = lastKnownAddresses[lastKnownAddresses.indexOfFirst { it.index == 2 }]
+    assertThat(lastKnownAddressIndex1.lastKnownAddressId.toString(), equalTo(lastKnownAddressId1.toString()))
+    assertThat(lastKnownAddressIndex2.lastKnownAddressId.toString(), equalTo(lastKnownAddressId2.toString()))
+    assertThat(lastKnownAddressIndex1.town, equalTo("first town"))
+    assertThat(lastKnownAddressIndex2.town, equalTo("second town"))
+    assertThat(lastKnownAddressIndex1.source.toString(), equalTo("LOOKUP"))
+    assertThat(lastKnownAddressIndex2.source.toString(), equalTo("MANUAL"))
+    assertThat(lastKnownAddressIndex2.line2, equalTo(null))
+    assertThat(lastKnownAddressIndex2.postcode, equalTo(null))
+  }
+
+  @Test
+  fun `add a LastKnownAddress with an incorrect recallId returns NOT_FOUND with message`() {
+    val notFoundRecallId = ::RecallId.random()
+    val createLastKnownAddressRequest = CreateLastKnownAddressRequest(
+      notFoundRecallId,
+      "address line 1",
+      "some line 2",
+      "some town",
+      "the postcode",
+      AddressSource.MANUAL
+    )
+
+    val expectedStatus = HttpStatus.NOT_FOUND
+    val response = authenticatedClient.lastKnownAddress(createLastKnownAddressRequest, expectedStatus, ErrorResponse::class.java)
+
+    assertThat(response, present())
+    assertThat(response, equalTo(ErrorResponse(expectedStatus, "RecallNotFoundException(recallId=$notFoundRecallId)")))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
@@ -86,8 +86,8 @@ class LastKnownAddressComponentTest : ComponentTestBase() {
     // There is no contract for the order of LastKnownAddresses but the index must be one-based incrementing positive integers, hence 1, 2, etc.
     val lastKnownAddressIndex1 = lastKnownAddresses[lastKnownAddresses.indexOfFirst { it.index == 1 }]
     val lastKnownAddressIndex2 = lastKnownAddresses[lastKnownAddresses.indexOfFirst { it.index == 2 }]
-    assertThat(lastKnownAddressIndex1.lastKnownAddressId.toString(), equalTo(lastKnownAddressId1.toString()))
-    assertThat(lastKnownAddressIndex2.lastKnownAddressId.toString(), equalTo(lastKnownAddressId2.toString()))
+    assertThat(lastKnownAddressIndex1.lastKnownAddressId, equalTo(lastKnownAddressId1))
+    assertThat(lastKnownAddressIndex2.lastKnownAddressId, equalTo(lastKnownAddressId2))
     assertThat(lastKnownAddressIndex1.town, equalTo("first town"))
     assertThat(lastKnownAddressIndex2.town, equalTo("second town"))
     assertThat(lastKnownAddressIndex1.source.toString(), equalTo("LOOKUP"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/pact/provider/ManageRecallsUIPactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/pact/provider/ManageRecallsUIPactTest.kt
@@ -80,6 +80,7 @@ class ManagerRecallsUiAuthorizedPactTest : ManagerRecallsUiPactTestBase() {
     recallReasonAuditRepository.deleteAll()
     recallAuditRepository.deleteAll()
     missingDocumentsRecordRepository.deleteAll()
+    lastKnownAddressRepository.deleteAll()
     documentRepository.deleteAll()
     recallRepository.deleteAll()
 
@@ -158,6 +159,7 @@ class ManagerRecallsUiAuthorizedPactTest : ManagerRecallsUiPactTestBase() {
         licenceNameCategory = NameFormatCategory.FIRST_LAST,
         documents = emptySet(),
         missingDocumentsRecords = emptySet(),
+        lastKnownAddresses = emptySet(),
         assignee = userIdOnes.value
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressControllerTest.kt
@@ -1,0 +1,125 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.controller
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.extractor.TokenExtractor
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddress
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddressRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomIndex
+import java.util.UUID
+
+class LastKnownAddressControllerTest {
+  private val recallRepository = mockk<RecallRepository>()
+  private val lastKnownAddressRepository = mockk<LastKnownAddressRepository>()
+  private val tokenExtractor = mockk<TokenExtractor>()
+
+  private val underTest = LastKnownAddressController(
+    recallRepository,
+    lastKnownAddressRepository,
+    tokenExtractor
+  )
+
+  private val recallId = ::RecallId.random()
+
+  @Test
+  fun `stores first lastKnownAddress with index 1, valid ids and passed in address properties`() {
+    val recall = mockk<Recall>()
+    val savedLastKnownAddress = slot<LastKnownAddress>()
+    val lastKnownAddress = mockk<LastKnownAddress>()
+    val bearerToken = "BEARER TOKEN"
+    val userId = ::UserId.random()
+    val lastKnownAddressId = ::LastKnownAddressId.random()
+
+    val line1 = "address line 1"
+    val line2 = "address line 2"
+    val town = "some town"
+    val postcode = "some postcode"
+    val source = AddressSource.LOOKUP
+
+    every { recall.lastKnownAddresses } returns emptySet()
+    every { recallRepository.getByRecallId(recallId) } returns recall
+    every { tokenExtractor.getTokenFromHeader(bearerToken) } returns TokenExtractor.Token(userId.toString())
+    every { lastKnownAddressRepository.save(capture(savedLastKnownAddress)) } returns lastKnownAddress
+    every { lastKnownAddress.id() } returns lastKnownAddressId
+
+    val request = CreateLastKnownAddressRequest(
+      recallId, line1, line2, town, postcode, source
+    )
+
+    val response = underTest.createLastKnownAddress(request, bearerToken)
+
+    assertThat(savedLastKnownAddress.captured.index, equalTo(1))
+    assertThat(UUID.fromString(savedLastKnownAddress.captured.id.toString()), present())
+    assertThat(savedLastKnownAddress.captured.recallId, equalTo(recallId.value))
+    assertThat(savedLastKnownAddress.captured.line1, equalTo(line1))
+    assertThat(savedLastKnownAddress.captured.line2, equalTo(line2))
+    assertThat(savedLastKnownAddress.captured.town, equalTo(town))
+    assertThat(savedLastKnownAddress.captured.postcode, equalTo(postcode))
+    assertThat(savedLastKnownAddress.captured.source, equalTo(source))
+    assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
+    assertThat(
+      response.body,
+      equalTo(
+        lastKnownAddressId
+      )
+    )
+  }
+
+  @Test
+  fun `stores next lastKnownAddress with previous maximum index plus 1 and passed in address properties`() {
+    val recall = mockk<Recall>()
+    val savedLastKnownAddress = slot<LastKnownAddress>()
+    val address = mockk<LastKnownAddress>()
+    val bearerToken = "BEARER TOKEN"
+    val userId = ::UserId.random()
+    val lastKnownAddressId = ::LastKnownAddressId.random()
+
+    val line1 = "address line 1"
+    val line2 = null
+    val town = "some town"
+    val postcode = null
+    val source = AddressSource.MANUAL
+
+    val prexistingLastKnownAddress = mockk<LastKnownAddress>()
+    every { recall.lastKnownAddresses } returns setOf(prexistingLastKnownAddress)
+    val previousMaxIndex = randomIndex()
+    every { prexistingLastKnownAddress.index } returns previousMaxIndex
+    every { recallRepository.getByRecallId(recallId) } returns recall
+    every { tokenExtractor.getTokenFromHeader(bearerToken) } returns TokenExtractor.Token(userId.toString())
+    every { lastKnownAddressRepository.save(capture(savedLastKnownAddress)) } returns address
+    every { address.id() } returns lastKnownAddressId
+
+    val request = CreateLastKnownAddressRequest(
+      recallId, line1, line2, town, postcode, source
+    )
+
+    val response = underTest.createLastKnownAddress(request, bearerToken)
+
+    assertThat(savedLastKnownAddress.captured.index, equalTo(previousMaxIndex + 1))
+    assertThat(savedLastKnownAddress.captured.line1, equalTo(line1))
+    assertThat(savedLastKnownAddress.captured.line2, equalTo(null))
+    assertThat(savedLastKnownAddress.captured.town, equalTo(town))
+    assertThat(savedLastKnownAddress.captured.postcode, equalTo(null))
+    assertThat(savedLastKnownAddress.captured.source, equalTo(source))
+    assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
+    assertThat(
+      response.body,
+      equalTo(
+        lastKnownAddressId
+      )
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
@@ -16,20 +16,17 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.encodeToBase64String
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MissingDocumentsRecordId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.DocumentService
-import uk.gov.justice.digital.hmpps.managerecallsapi.service.UserDetailsService
 
 class MissingDocumentsRecordControllerTest {
   private val recallRepository = mockk<RecallRepository>()
   private val missingDocumentsRecordRepository = mockk<MissingDocumentsRecordRepository>()
   private val documentService = mockk<DocumentService>()
   private val tokenExtractor = mockk<TokenExtractor>()
-  private val userDetailService = mockk<UserDetailsService>()
 
   private val underTest = MissingDocumentsRecordController(
     recallRepository,
@@ -98,13 +95,11 @@ class MissingDocumentsRecordControllerTest {
     val bearerToken = "BEARER TOKEN"
     val userId = ::UserId.random()
     val missingDocumentsRecordId = ::MissingDocumentsRecordId.random()
-    val fullName = FullName("Harry Potter")
     val details = "detail"
 
     val existingRecord = mockk<MissingDocumentsRecord>()
     every { recall.missingDocumentsRecords } returns setOf(existingRecord)
     every { existingRecord.version } returns 1
-    every { userDetailService.get(userId).fullName() } returns fullName
     every { recallRepository.getByRecallId(recallId) } returns recall
     every {
       documentService.scanAndStoreDocument(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/IntegrationTestBase.kt
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.integration.db
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddressRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetailsRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
+import java.time.OffsetDateTime
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest
+@ActiveProfiles("db-test")
+@TestInstance(PER_CLASS)
+abstract class IntegrationTestBase {
+  final val recallId = ::RecallId.random()
+  final val createdByUserId = ::UserId.random()
+  val currentUserId = ::UserId.random()
+  final val nomsNumber = randomNoms()
+  val recall = Recall(recallId, nomsNumber, createdByUserId, OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
+
+  @Autowired
+  protected lateinit var userDetailsRepository: UserDetailsRepository
+
+  @Autowired
+  protected lateinit var recallRepository: RecallRepository
+
+  @Autowired
+  protected lateinit var lastKnownAddressRepository: LastKnownAddressRepository
+
+  @BeforeEach
+  fun `setup createdBy user`() {
+    createUserDetails(createdByUserId)
+    createUserDetails(currentUserId)
+  }
+
+  private fun createUserDetails(userId: UserId) {
+    userDetailsRepository.save(
+      UserDetails(
+        userId,
+        FirstName("Test"),
+        LastName("User"),
+        "",
+        Email("test@user.com"),
+        PhoneNumber("09876543210"),
+        CaseworkerBand.FOUR_PLUS,
+        OffsetDateTime.now()
+      )
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/LastKnownAddressRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/LastKnownAddressRepositoryIntegrationTest.kt
@@ -1,0 +1,106 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.integration.db
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.startsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.dao.DataIntegrityViolationException
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
+import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddress
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+import java.time.OffsetDateTime
+import javax.transaction.Transactional
+
+class LastKnownAddressRepositoryIntegrationTest : IntegrationTestBase() {
+
+  // Note: when using @Transactional to clean up after the tests we need to 'flush' to trigger the DB constraints, hence use of saveAndFlush()
+  @Test
+  @Transactional
+  fun `can save and flush one then a second last known address with valid index values for an existing recall`() {
+    recallRepository.save(recall, currentUserId)
+
+    val lastKnownAddressId1 = ::LastKnownAddressId.random()
+    val lastKnownAddress1 = lastKnownAddress(lastKnownAddressId1, 1)
+
+    lastKnownAddressRepository.saveAndFlush(lastKnownAddress1)
+    val retrieved1 = lastKnownAddressRepository.getById(lastKnownAddressId1.value)
+
+    assertThat(retrieved1, equalTo(lastKnownAddress1))
+
+    val lastKnownAddressId2 = ::LastKnownAddressId.random()
+    val lastKnownAddress2 = lastKnownAddress(lastKnownAddressId2, 2)
+
+    lastKnownAddressRepository.saveAndFlush(lastKnownAddress2)
+    val retrieved2 = lastKnownAddressRepository.getById(lastKnownAddressId2.value)
+
+    assertThat(retrieved2, equalTo(lastKnownAddress2))
+  }
+
+  @Test
+  @Transactional
+  fun `cannot save and flush two last known addresses with the same index value for an existing recall`() {
+    recallRepository.save(recall, currentUserId)
+
+    val lastKnownAddressId1 = ::LastKnownAddressId.random()
+    val lastKnownAddress1 = lastKnownAddress(lastKnownAddressId1, 1)
+
+    lastKnownAddressRepository.saveAndFlush(lastKnownAddress1)
+    val retrieved1 = lastKnownAddressRepository.getById(lastKnownAddressId1.value)
+
+    assertThat(retrieved1, equalTo(lastKnownAddress1))
+
+    val lastKnownAddressId2 = ::LastKnownAddressId.random()
+    val lastKnownAddress2 = lastKnownAddress(lastKnownAddressId2, 1)
+
+    val thrown = assertThrows<DataIntegrityViolationException> {
+      lastKnownAddressRepository.saveAndFlush(lastKnownAddress2)
+    }
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
+  }
+
+  @Test
+  @Transactional
+  fun `cannot save and flush a last known address with an invalid(0) index value for an existing recall`() {
+    recallRepository.save(recall, currentUserId)
+
+    val lastKnownAddressId1 = ::LastKnownAddressId.random()
+    val lastKnownAddress1 = lastKnownAddress(lastKnownAddressId1, 0)
+
+    val thrown = assertThrows<DataIntegrityViolationException> {
+      lastKnownAddressRepository.saveAndFlush(lastKnownAddress1)
+    }
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
+  }
+
+  @Test
+  @Transactional
+  fun `cannot save and flush a last known address with an invalid(negative) index value for an existing recall`() {
+    recallRepository.save(recall, currentUserId)
+
+    val lastKnownAddressId1 = ::LastKnownAddressId.random()
+    val lastKnownAddress1 = lastKnownAddress(lastKnownAddressId1, -1)
+
+    val thrown = assertThrows<DataIntegrityViolationException> {
+      lastKnownAddressRepository.saveAndFlush(lastKnownAddress1)
+    }
+    assertThat(thrown.message!!, startsWith("could not execute statement"))
+  }
+
+  private fun lastKnownAddress(
+    lastKnownAddressId: LastKnownAddressId,
+    index: Int
+  ) = LastKnownAddress(
+    lastKnownAddressId,
+    recallId,
+    "Highwood Cottage, 43 Blandford Road",
+    null,
+    "Wareham",
+    "DT3 7HU",
+    AddressSource.MANUAL,
+    index,
+    createdByUserId,
+    OffsetDateTime.now()
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/random/RandomUtilities.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/random/RandomUtilities.kt
@@ -24,9 +24,9 @@ import kotlin.reflect.full.isSubclassOf
 
 internal fun fullyPopulatedRecall(recallId: RecallId = ::RecallId.random(), knownUserId: UserId? = null): Recall =
   fullyPopulatedInstance<Recall>().let { recall ->
-    // ensure recall length is valid for the random sentencing info as it is calculated on the fly
     recall.copy(
       id = recallId.value,
+      // ensure recall length is valid for the random sentencing info as it is calculated on the fly
       recallLength = recall.sentencingInfo?.calculateRecallLength(),
       assignee = (knownUserId ?: ::UserId.random()).value,
       assessedByUserId = (knownUserId ?: ::UserId.random()).value,
@@ -34,12 +34,11 @@ internal fun fullyPopulatedRecall(recallId: RecallId = ::RecallId.random(), know
       createdByUserId = (knownUserId ?: ::UserId.random()).value,
       lastUpdatedByUserId = (knownUserId ?: ::UserId.random()).value,
       dossierCreatedByUserId = (knownUserId ?: ::UserId.random()).value,
-      documents = recall.documents.map {
-        document ->
+      documents = recall.documents.map { document ->
         document.copy(
           recallId = recallId.value,
           // ensure document version is valid versus category
-          version = if (document.category.versioned) Random.nextInt(1, Int.MAX_VALUE) else null,
+          version = if (document.category.versioned) randomVersion() else null,
           createdByUserId = (knownUserId ?: ::UserId.random()).value
         )
       }.toSet(),
@@ -47,7 +46,14 @@ internal fun fullyPopulatedRecall(recallId: RecallId = ::RecallId.random(), know
         mdr.copy(
           recallId = recallId.value,
           emailId = recall.documents.random().id,
-          version = Random.nextInt(1, Int.MAX_VALUE),
+          version = randomVersion(),
+          createdByUserId = (knownUserId ?: ::UserId.random()).value
+        )
+      }.toSet(),
+      lastKnownAddresses = recall.lastKnownAddresses.map { lka ->
+        lka.copy(
+          recallId = recallId.value,
+          index = randomIndex(),
           createdByUserId = (knownUserId ?: ::UserId.random()).value
         )
       }.toSet()
@@ -105,6 +111,8 @@ private fun makeRandomSet(kclass: KClass<*>, type: KType): Set<Any> {
 
 fun <T : Validated<UUID>> ((UUID) -> T).zeroes() = this(UUID(0, 0))
 fun randomString(): String = RandomStringUtils.randomAlphanumeric(10)
+fun randomVersion(): Int = Random.nextInt(1, Int.MAX_VALUE)
+fun randomIndex(): Int = randomVersion()
 fun randomNoms() = NomsNumber(RandomStringUtils.randomAlphanumeric(7))
 fun randomPrisonId() = PrisonId(RandomStringUtils.randomAlphanumeric(6))
 fun randomCourtId() = CourtId(RandomStringUtils.randomAlphanumeric(6))


### PR DESCRIPTION
PUD-1319  API: Support saving and return of offender last known addresses versus Recalls
To follow: PACT uplift to test LastKnownAddresses on Recall response.