### PR TITLE
Clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ will apply ktlint styles to intellij and also add a pre-commit hook to format al
 
 ### Run the service locally on the command line
 
-Requires postgres and minio:
+Requires the following:
 
 ```
-docker compose up -d postgres minio
+docker compose up -d postgres minio fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api gotenberg clamav
 ```
 
 Start with dev profile:
@@ -53,7 +53,7 @@ Start with dev profile:
 SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
 ```
 
-You can now access the API at: http://localhost:8080
+You can now check the API is up and running at: http://localhost:8080/health/liveness
 
 ### Run in docker-compose
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,13 +65,19 @@ server:
     include-message: always
 
 management:
+#  TODO: PUD-1377 - do not expose the metrics and health endpoints publicly.
+#        This work is blocked by PUD-1231 (the replacement of SpringFox).
+#  server:
+#    port: 8081
   endpoints:
+    enabled-by-default: false
     web:
       base-path: /
       exposure:
-        include: 'info, health, metrics, prometheus'
+        include: 'info, health, prometheus'
   endpoint:
     health:
+      enabled: true
       cache:
         time-to-live: 2000ms
       show-components: always
@@ -79,10 +85,9 @@ management:
       probes:
         enabled: true
     info:
+      enabled: true
       cache:
         time-to-live: 2000ms
-    metrics:
-      enabled: true
     prometheus:
       enabled: true
   info:


### PR DESCRIPTION
- Update the getting started docs
- Clean up the actuator config
  - disable all endpoints by default
  - remove `metrics` (we weren't using them)

This also adds a note about the need to move the management endpoints
onto a separate port for PUD-1377.
