### PR TITLE
PUD-1399: Add CRO & DoB to recall.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/RestConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/RestConfiguration.kt
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestTemplate
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldName
@@ -70,6 +71,7 @@ object ManageRecallsApiJackson : ConfigurableJackson(
 
 private fun AutoMappingConfiguration<ObjectMapper>.withCustomMappings() = apply {
   text(::NomsNumber)
+  text(::CroNumber)
   text(::FirstName)
   text(::MiddleNames)
   text(::LastName)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/SpringFoxConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/SpringFoxConfig.kt
@@ -32,6 +32,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.ColumnName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldName
@@ -65,6 +66,7 @@ class SpringFoxConfig {
       .paths(PathSelectors.any())
       .build()
       .directModelSubstitute(NomsNumber::class.java, String::class.java)
+      .directModelSubstitute(CroNumber::class.java, String::class.java)
       .directModelSubstitute(FirstName::class.java, String::class.java)
       .directModelSubstitute(MiddleNames::class.java, String::class.java)
       .directModelSubstitute(LastName::class.java, String::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallController.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.MissingDocumentsRecord
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
@@ -140,6 +141,8 @@ class RecallController(
     firstName = this.firstName,
     middleNames = this.middleNames,
     lastName = this.lastName,
+    croNumber = this.croNumber,
+    dateOfBirth = this.dateOfBirth,
     licenceNameCategory = this.licenceNameCategory,
     status = this.status(),
     documents = latestDocuments(documents),
@@ -256,7 +259,9 @@ fun BookRecallRequest.toRecall(userUuid: UserId): Recall {
     now,
     this.firstName,
     this.middleNames,
-    this.lastName
+    this.lastName,
+    this.croNumber,
+    this.dateOfBirth
   )
 }
 
@@ -264,7 +269,9 @@ data class BookRecallRequest(
   val nomsNumber: NomsNumber,
   val firstName: FirstName,
   val middleNames: MiddleNames?,
-  val lastName: LastName
+  val lastName: LastName,
+  val croNumber: CroNumber,
+  val dateOfBirth: LocalDate,
 )
 
 data class RecallResponse(
@@ -276,6 +283,8 @@ data class RecallResponse(
   val firstName: FirstName,
   val middleNames: MiddleNames?,
   val lastName: LastName,
+  val croNumber: CroNumber,
+  val dateOfBirth: LocalDate,
   val licenceNameCategory: NameFormatCategory,
   val status: Status,
   val documents: List<Api.RecallDocument> = emptyList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Converters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Converters.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.managerecallsapi.db
 
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -18,6 +19,7 @@ class LastNameJpaConverter : CustomJpaConverter<LastName, String>({ it.value }, 
 class EmailJpaConverter : CustomJpaConverter<Email, String>({ it.value }, ::Email)
 class PhoneNumberJpaConverter : CustomJpaConverter<PhoneNumber, String>({ it.value }, ::PhoneNumber)
 class NomsNumberJpaConverter : CustomJpaConverter<NomsNumber, String>({ it.value }, ::NomsNumber)
+class CroNumberJpaConverter : CustomJpaConverter<CroNumber, String>({ it.value }, ::CroNumber)
 class PrisonIdJpaConverter : CustomJpaConverter<PrisonId?, String?>({ it?.value }, { it?.let { PrisonId(it) } })
 class CourtIdJpaConverter : CustomJpaConverter<CourtId?, String?>({ it?.value }, { it?.let { CourtId(it) } })
 class PoliceForceIdJpaConverter : CustomJpaConverter<PoliceForceId?, String?>({ it?.value }, { it?.let { PoliceForceId(it) } })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Recall.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/Recall.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallType
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Status
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PersonName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -65,6 +66,11 @@ data class Recall(
   @Column(nullable = false)
   @Convert(converter = LastNameJpaConverter::class)
   val lastName: LastName,
+  // FIXME - once Prod has values, this needs setting @Column(nullable = false)
+  @Convert(converter = CroNumberJpaConverter::class)
+  val croNumber: CroNumber,
+  // @Column(nullable = false)
+  val dateOfBirth: LocalDate,
   @Column(nullable = false)
   @Enumerated(STRING)
   val licenceNameCategory: NameFormatCategory,
@@ -142,6 +148,8 @@ data class Recall(
     firstName: FirstName,
     middleNames: MiddleNames?,
     lastName: LastName,
+    croNumber: CroNumber,
+    dateOfBirth: LocalDate,
     licenceNameCategory: NameFormatCategory = FIRST_LAST,
     lastUpdatedByUserId: UserId = createdByUserId,
     lastUpdatedDateTime: OffsetDateTime = createdDateTime,
@@ -198,6 +206,8 @@ data class Recall(
       firstName,
       middleNames,
       lastName,
+      croNumber,
+      dateOfBirth,
       licenceNameCategory,
       documents,
       missingDocumentsRecords,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextFactory.kt
@@ -47,6 +47,7 @@ class RecallNotificationContextFactory(
 ) {
   fun createContext(recallId: RecallId, currentUserId: UserId): RecallNotificationContext {
     val recall = recallRepository.getByRecallId(recallId)
+    // FIXME - no longer need to look these values up
     val prisoner = prisonerOffenderSearchClient.prisonerByNomsNumber(recall.nomsNumber).block()!!
     val currentUserDetails = userDetailsService.get(currentUserId)
     val currentPrisonName = prisonLookupService.getPrisonName(recall.currentPrison!!)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/domain/domain.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/domain/domain.kt
@@ -14,6 +14,7 @@ import java.util.UUID
  */
 
 class NomsNumber(value: String) : Validated<String>(value, notBlank, alphanumeric)
+class CroNumber(value: String) : Validated<String>(value, notBlank)
 class RecallId(value: UUID) : Validated<UUID>(value)
 class DocumentId(value: UUID) : Validated<UUID>(value)
 class MissingDocumentsRecordId(value: UUID) : Validated<UUID>(value)

--- a/src/main/resources/db/migration/V75__Add_cro_and_dob_to_recall.sql
+++ b/src/main/resources/db/migration/V75__Add_cro_and_dob_to_recall.sql
@@ -1,0 +1,3 @@
+ALTER TABLE recall
+    ADD COLUMN cro_number TEXT,
+    ADD COLUMN date_of_birth DATE;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AssignRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AssignRecallComponentTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Status
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
@@ -26,6 +27,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneId
 import kotlin.jvm.Throws
@@ -52,7 +54,7 @@ class AssignRecallComponentTest : ComponentTestBase() {
     setupUserDetailsFor(assignee)
     setupUserDetailsFor(createdByUserId)
 
-    val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
+    val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"), CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1))
 
     recallRepository.save(recall, createdByUserId)
     userDetailsRepository.save(
@@ -79,6 +81,8 @@ class AssignRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           OffsetDateTime.now(fixedClock), FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON,
           assignee = assignee,
@@ -105,6 +109,7 @@ class AssignRecallComponentTest : ComponentTestBase() {
       FirstName("Barrie"),
       null,
       LastName("Badger"),
+      CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1),
       assignee = assignee
     )
     recallRepository.save(recall, createdByUserId)
@@ -120,6 +125,8 @@ class AssignRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           OffsetDateTime.now(fixedClock), FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON
         )
@@ -146,6 +153,7 @@ class AssignRecallComponentTest : ComponentTestBase() {
       FirstName("Barrie"),
       null,
       LastName("Badger"),
+      CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1),
       assignee = assignee
     )
     recallRepository.save(recall, createdByUserId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/BookRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/BookRecallComponentTest.kt
@@ -9,16 +9,27 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.NameFormatCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
+import java.time.LocalDate
 
 class BookRecallComponentTest : ComponentTestBase() {
 
   @Test
   fun `book a recall creates a recall and returns recall details`() {
     val nomsNumber = NomsNumber("123456")
-    val response = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Bobby"), null, LastName("Badger")))
+    val response = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName("Bobby"),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
 
     assertThat(
       response,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.REVOCAT
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.UNCATEGORISED
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.encodeToBase64String
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
@@ -36,7 +37,14 @@ import java.time.LocalDate
 
 class DocumentComponentTest : ComponentTestBase() {
   private val nomsNumber = NomsNumber("123456")
-  private val bookRecallRequest = BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger"))
+  private val bookRecallRequest = BookRecallRequest(
+    nomsNumber,
+    FirstName("Barrie"),
+    null,
+    LastName("Badger"),
+    CroNumber("1234/56A"),
+    LocalDate.now()
+  )
   private val versionedDocumentCategory = PART_A_RECALL_REPORT
   private val documentContents = "Expected Generated PDF".toByteArray()
   private val base64EncodedDocumentContents = documentContents.encodeToBase64String()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.encodeToBase64String
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+import java.time.LocalDate
 import java.util.UUID
 import java.util.stream.Stream
 
@@ -35,7 +37,14 @@ class EndpointSecurityComponentTest : ComponentTestBase() {
 
   private val nomsNumber = NomsNumber("123456")
   private val details = "Some details"
-  private val bookRecallRequest = BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger"))
+  private val bookRecallRequest = BookRecallRequest(
+    nomsNumber,
+    FirstName("Barrie"),
+    null,
+    LastName("Badger"),
+    CroNumber("1234/56A"),
+    LocalDate.now()
+  )
   private val fileBytes = "content".toByteArray()
   private val category = DocumentCategory.values().random()
   private val uploadDocumentRequest = UploadDocumentRequest(category, fileBytes.encodeToBase64String(), "part_a.pdf", details)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GenerateDossierComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GenerateDossierComponentTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.documents.base64EncodedFile
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.dossier.RecallClassPathResource.FixedTermRecallInformationLeafletEnglish
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.readText
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
@@ -53,7 +54,16 @@ class GenerateDossierComponentTest : ComponentTestBase() {
       revocationOrderFile.readText(),
     )
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName(firstName), null, LastName("Badger")))
+    val recall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName(firstName),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     authenticatedClient.updateRecall(
       recall.recallId,
       UpdateRecallRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallComponentTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.NameFormatCatego
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Status
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
@@ -38,7 +39,9 @@ class GetRecallComponentTest : ComponentTestBase() {
         now,
         FirstName("Barrie"),
         null,
-        LastName("Badger")
+        LastName("Badger"),
+        CroNumber("ABC/1234A"),
+        LocalDate.of(1999, 12, 1)
       ),
       createdByUserId
     )
@@ -57,6 +60,8 @@ class GetRecallComponentTest : ComponentTestBase() {
           FirstName("Barrie"),
           null,
           LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON
         )
@@ -85,6 +90,8 @@ class GetRecallComponentTest : ComponentTestBase() {
       .jsonPath("$.firstName").isEqualTo(fullyPopulatedRecall.firstName.toString())
       .jsonPath("$.middleNames").isEqualTo(fullyPopulatedRecall.middleNames.toString())
       .jsonPath("$.lastName").isEqualTo(fullyPopulatedRecall.lastName.toString())
+      .jsonPath("$.croNumber").isEqualTo(fullyPopulatedRecall.croNumber.toString())
+      .jsonPath("$.dateOfBirth").isEqualTo(fullyPopulatedRecall.dateOfBirth.toString())
       .jsonPath("$.licenceNameCategory").isEqualTo(fullyPopulatedRecall.licenceNameCategory.toString())
       .jsonPath("$.documents.length()").isEqualTo(1)
       .jsonPath("$.missingDocumentsRecords.length()").isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallNotificationComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallNotificationComponentTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.RECALL_
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.REVOCATION_ORDER
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.encodeToBase64String
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
@@ -34,7 +35,16 @@ class GetRecallNotificationComponentTest : ComponentTestBase() {
   @Test
   fun `get recall notification returns merged recall summary and revocation order and then generate recall notification generates new version but reuses existing revocation order`() {
     val userId = authenticatedClient.userId
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName(firstName), null, LastName("Badger")))
+    val recall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName(firstName),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     updateRecallWithRequiredInformationForTheRecallNotification(recall.recallId, userId, true)
 
     expectAPrisonerWillBeFoundFor(nomsNumber, firstName)
@@ -86,7 +96,16 @@ class GetRecallNotificationComponentTest : ComponentTestBase() {
   @Test
   fun `get recall notification for not in custody includes offender notification and police notification`() {
     val userId = authenticatedClient.userId
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName(firstName), null, LastName("Badger")))
+    val recall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName(firstName),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     updateRecallWithRequiredInformationForTheRecallNotification(recall.recallId, userId, false)
 
     expectAPrisonerWillBeFoundFor(nomsNumber, firstName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallsComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallsComponentTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.NameFormatCatego
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Status
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MiddleNames
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneId
 
@@ -24,8 +26,29 @@ class GetRecallsComponentTest : ComponentTestBase() {
     val createdByUserId = authenticatedClient.userId
 
     val now = OffsetDateTime.ofInstant(Instant.parse("2021-10-04T14:15:43.682078Z"), ZoneId.of("UTC"))
-    val recall1 = Recall(::RecallId.random(), NomsNumber("123456"), createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
-    val recall2 = Recall(::RecallId.random(), NomsNumber("987654"), createdByUserId, now, FirstName("Barrie"), MiddleNames("Barnie"), LastName("Badger"), licenceNameCategory = FIRST_MIDDLE_LAST)
+    val recall1 = Recall(
+      ::RecallId.random(),
+      NomsNumber("123456"),
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
+    val recall2 = Recall(
+      ::RecallId.random(),
+      NomsNumber("987654"),
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      MiddleNames("Barnie"),
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
+      licenceNameCategory = FIRST_MIDDLE_LAST
+    )
     recallRepository.save(recall1, createdByUserId)
     recallRepository.save(recall2, createdByUserId)
 
@@ -43,6 +66,8 @@ class GetRecallsComponentTest : ComponentTestBase() {
           FirstName("Barrie"),
           null,
           LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           FIRST_LAST,
           Status.BEING_BOOKED_ON
         ),
@@ -55,6 +80,8 @@ class GetRecallsComponentTest : ComponentTestBase() {
           FirstName("Barrie"),
           MiddleNames("Barnie"),
           LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           FIRST_MIDDLE_LAST,
           Status.BEING_BOOKED_ON
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
@@ -11,16 +11,25 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.CreateLastKnownAddressRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+import java.time.LocalDate
 
 class LastKnownAddressComponentTest : ComponentTestBase() {
   private val nomsNumber = NomsNumber("123456")
-  private val bookRecallRequest = BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger"))
+  private val bookRecallRequest = BookRecallRequest(
+    nomsNumber,
+    FirstName("Barrie"),
+    null,
+    LastName("Badger"),
+    CroNumber("1234/56A"),
+    LocalDate.now()
+  )
 
   @Test
   fun `create and retrieve one LastKnownAddress for a recall`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/MissingDocumentsRecordComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/MissingDocumentsRecordComponentTest.kt
@@ -12,14 +12,23 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallReques
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.MissingDocumentsRecordRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.PART_A_RECALL_REPORT
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.encodeToBase64String
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MissingDocumentsRecordId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
+import java.time.LocalDate
 
 class MissingDocumentsRecordComponentTest : ComponentTestBase() {
   private val nomsNumber = NomsNumber("123456")
-  private val bookRecallRequest = BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger"))
+  private val bookRecallRequest = BookRecallRequest(
+    nomsNumber,
+    FirstName("Barrie"),
+    null,
+    LastName("Badger"),
+    CroNumber("1234/56A"),
+    LocalDate.now()
+  )
   private val documentContents = "Expected Generated PDF".toByteArray()
   private val base64EncodedDocumentContents = documentContents.encodeToBase64String()
   private val fileName = "fileName"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/RecallAuditComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/RecallAuditComponentTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.ReasonForRecall.
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.ReasonForRecall.OTHER
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.UpdateRecallRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FieldPath
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
@@ -55,7 +56,16 @@ class RecallAuditComponentTest : ComponentTestBase() {
     expectedValue: Any
   ) {
     val savedRecall =
-      authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Brian"), null, LastName("Badgering")))
+      authenticatedClient.bookRecall(
+        BookRecallRequest(
+          nomsNumber,
+          FirstName("Brian"),
+          null,
+          LastName("Badgering"),
+          CroNumber("1234/56A"),
+          LocalDate.now()
+        )
+      )
     val recallId = savedRecall.recallId
 
     val updatedRecall = authenticatedClient.updateRecall(recallId, updateRequest)
@@ -70,7 +80,16 @@ class RecallAuditComponentTest : ComponentTestBase() {
 
   @Test
   fun `get recallEmailReceivedDateTime (OffsetDateTime value) audit history`() {
-    val savedRecall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Brian"), null, LastName("Badgering")))
+    val savedRecall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName("Brian"),
+        null,
+        LastName("Badgering"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     val recallId = savedRecall.recallId
 
     val recallEmailReceivedDateTime = OffsetDateTime.now()
@@ -87,7 +106,16 @@ class RecallAuditComponentTest : ComponentTestBase() {
 
   @Test
   fun `get reasonsForRecall (Array value) audit history`() {
-    val savedRecall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Brian"), null, LastName("Badgering")))
+    val savedRecall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName("Brian"),
+        null,
+        LastName("Badgering"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     val recallId = savedRecall.recallId
 
     val updatedRecall = authenticatedClient.updateRecall(recallId, UpdateRecallRequest(reasonsForRecall = setOf(OTHER, ELM_EQUIPMENT_TAMPER)))
@@ -104,7 +132,16 @@ class RecallAuditComponentTest : ComponentTestBase() {
   @Test
   fun `get audit summary for a recall including reasons for recall`() {
     val savedRecall =
-      authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Brian"), null, LastName("Badgering")))
+      authenticatedClient.bookRecall(
+        BookRecallRequest(
+          nomsNumber,
+          FirstName("Brian"),
+          null,
+          LastName("Badgering"),
+          CroNumber("1234/56A"),
+          LocalDate.now()
+        )
+      )
     val recallId = savedRecall.recallId
 
     val auditList = authenticatedClient.auditSummaryForRecall(recallId)
@@ -124,10 +161,11 @@ class RecallAuditComponentTest : ComponentTestBase() {
         )
     )
 
-    assertThat(auditList[2].fieldName, equalTo(FieldName("lastUpdatedDateTime")))
-    assertThat(auditList[2].updatedByUserName, equalTo(FullName("Bertie Badger")))
-    assertThat(auditList[2].auditCount, equalTo(1))
-    assertOffsetDateTimesEqual(auditList[2].updatedDateTime, savedRecall.lastUpdatedDateTime)
+    val lastUpdatedTimeAudit = auditList.first { it.fieldName.value == "lastUpdatedDateTime" }
+    assertThat(lastUpdatedTimeAudit.fieldName, equalTo(FieldName("lastUpdatedDateTime")))
+    assertThat(lastUpdatedTimeAudit.updatedByUserName, equalTo(FullName("Bertie Badger")))
+    assertThat(lastUpdatedTimeAudit.auditCount, equalTo(1))
+    assertOffsetDateTimesEqual(lastUpdatedTimeAudit.updatedDateTime, savedRecall.lastUpdatedDateTime)
 
     val updatedRecall = authenticatedClient.updateRecall(recallId, UpdateRecallRequest(contraband = true, reasonsForRecall = setOf(ELM_EQUIPMENT_TAMPER, ELM_FAILURE_CHARGE_BATTERY, OTHER)))
 
@@ -156,10 +194,10 @@ class RecallAuditComponentTest : ComponentTestBase() {
     assertThat(updatedAuditList[0].auditCount, equalTo(1))
     assertOffsetDateTimesEqual(updatedAuditList[0].updatedDateTime, updatedRecall.lastUpdatedDateTime)
 
-    assertThat(updatedAuditList[3].fieldName, equalTo(FieldName("lastUpdatedDateTime")))
-    assertThat(updatedAuditList[3].updatedByUserName, equalTo(FullName("Bertie Badger")))
-    assertThat(updatedAuditList[3].auditCount, equalTo(2))
-    assertOffsetDateTimesEqual(updatedAuditList[3].updatedDateTime, updatedRecall.lastUpdatedDateTime)
+    val lastUpdatedTimeUpdatedAudit = updatedAuditList.first { it.fieldName.value == "lastUpdatedDateTime" }
+    assertThat(lastUpdatedTimeUpdatedAudit.updatedByUserName, equalTo(FullName("Bertie Badger")))
+    assertThat(lastUpdatedTimeUpdatedAudit.auditCount, equalTo(2))
+    assertOffsetDateTimesEqual(lastUpdatedTimeUpdatedAudit.updatedDateTime, updatedRecall.lastUpdatedDateTime)
 
     val reasonsForRecallAudit = updatedAuditList.first { it.fieldName.value == "reasonsForRecall" }
     assertThat(reasonsForRecallAudit.fieldPath, equalTo(FieldPath("reasonsForRecall")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/SearchRecallsComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/SearchRecallsComponentTest.kt
@@ -7,12 +7,14 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallSearchRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Status
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneId
 
@@ -23,10 +25,50 @@ class SearchRecallsComponentTest : ComponentTestBase() {
     val nomsNumberToSearch = randomNoms()
     val now = OffsetDateTime.ofInstant(Instant.parse("2021-10-04T14:15:43.682078Z"), ZoneId.of("UTC"))
     val createdByUserId = authenticatedClient.userId
-    val recall1 = Recall(::RecallId.random(), randomNoms(), createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
-    val recall2 = Recall(::RecallId.random(), nomsNumberToSearch, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
-    val recall3 = Recall(::RecallId.random(), nomsNumberToSearch, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
-    val recall4 = Recall(::RecallId.random(), randomNoms(), createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
+    val recall1 = Recall(
+      ::RecallId.random(),
+      randomNoms(),
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
+    val recall2 = Recall(
+      ::RecallId.random(),
+      nomsNumberToSearch,
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
+    val recall3 = Recall(
+      ::RecallId.random(),
+      nomsNumberToSearch,
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
+    val recall4 = Recall(
+      ::RecallId.random(),
+      randomNoms(),
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
     recallRepository.saveAll(listOf(recall1, recall2, recall3, recall4))
 
     val response = authenticatedClient.searchRecalls(RecallSearchRequest(nomsNumberToSearch))
@@ -43,6 +85,8 @@ class SearchRecallsComponentTest : ComponentTestBase() {
           FirstName("Barrie"),
           null,
           LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON
         ),
@@ -55,6 +99,8 @@ class SearchRecallsComponentTest : ComponentTestBase() {
           FirstName("Barrie"),
           null,
           LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/UpdateRecallComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/UpdateRecallComponentTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.SentenceLength
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.SentencingInfo
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -64,7 +65,9 @@ class UpdateRecallComponentTest : ComponentTestBase() {
         now,
         FirstName("Barrie"),
         null,
-        LastName("Badger")
+        LastName("Badger"),
+        CroNumber("ABC/1234A"),
+        LocalDate.of(1999, 12, 1)
       ),
       createdByUserId
     )
@@ -94,6 +97,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_MIDDLE_LAST,
           Status.BEING_BOOKED_ON,
           lastReleasePrison = PrisonId("MWI"),
@@ -167,6 +172,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON,
           recallLength = TWENTY_EIGHT_DAYS,
@@ -195,6 +202,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON,
           bookingNumber = bookingNumber
@@ -223,6 +232,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON,
           localPoliceForceId = policeForceId
@@ -251,6 +262,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON,
           licenceConditionsBreached = "Breached",
@@ -280,6 +293,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON,
           agreeWithRecall = AgreeWithRecall.YES,
@@ -308,6 +323,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.RECALL_NOTIFICATION_ISSUED,
           recallNotificationEmailSentDateTime = updateRecallRequest.recallNotificationEmailSentDateTime,
@@ -339,6 +356,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           status = Status.DOSSIER_ISSUED,
           dossierEmailSentDate = updateRecallRequest.dossierEmailSentDate,
@@ -368,6 +387,8 @@ class UpdateRecallComponentTest : ComponentTestBase() {
           createdByUserId,
           now,
           fixedClockTime, FirstName("Barrie"), null, LastName("Badger"),
+          CroNumber("ABC/1234A"),
+          LocalDate.of(1999, 12, 1),
           NameFormatCategory.FIRST_LAST,
           Status.BEING_BOOKED_ON,
           additionalLicenceConditions = request.additionalLicenceConditions,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/pact/provider/ManageRecallsUIPactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/pact/provider/ManageRecallsUIPactTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.MissingDocumentsRecord
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.toBase64DecodedByteArray
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
@@ -268,7 +269,9 @@ class ManagerRecallsUiAuthorizedPactTest : ManagerRecallsUiPactTestBase() {
         OffsetDateTime.now(),
         FirstName("Barrie"),
         null,
-        LastName("Badger")
+        LastName("Badger"),
+        CroNumber("ABC/1234A"),
+        LocalDate.of(1999, 12, 1)
       ),
       createdByUserId
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RecallControllerTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.PART_A_
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
@@ -63,7 +64,15 @@ class RecallControllerTest {
   private val firstName = FirstName("Barrie")
   private val middleNames = MiddleNames("Barnie")
   private val lastName = LastName("Badger")
-  private val recallRequest = BookRecallRequest(nomsNumber, firstName, null, lastName)
+  private val croNumber = CroNumber("ABC/1234A")
+  private val recallRequest = BookRecallRequest(
+    nomsNumber,
+    firstName,
+    null,
+    lastName,
+    croNumber,
+    LocalDate.of(1999, 12, 1)
+  )
   private val fileName = "fileName"
   private val now = OffsetDateTime.now()
   private val bookedByUserId = ::UserId.random()
@@ -71,13 +80,19 @@ class RecallControllerTest {
   private val dossierCreatedByUserId = ::UserId.random()
   private val details = "Document details"
 
-  private val recall = Recall(recallId, nomsNumber, createdByUserId, now, firstName, null, lastName)
+  private val recall = Recall(
+    recallId, nomsNumber, createdByUserId, now, firstName, null, lastName,
+    croNumber, LocalDate.of(1999, 12, 1)
+  )
 
   private val updateRecallRequest =
     UpdateRecallRequest(lastReleasePrison = PrisonId("ABC"), currentPrison = PrisonId("DEF"))
 
   private val recallResponse =
-    RecallResponse(recallId, nomsNumber, createdByUserId, now, now, firstName, null, lastName, NameFormatCategory.FIRST_LAST, Status.BEING_BOOKED_ON)
+    RecallResponse(
+      recallId, nomsNumber, createdByUserId, now, now, firstName, null, lastName,
+      croNumber, LocalDate.of(1999, 12, 1), NameFormatCategory.FIRST_LAST, Status.BEING_BOOKED_ON
+    )
 
   @Test
   fun `book recall returns request with id`() {
@@ -94,10 +109,24 @@ class RecallControllerTest {
   }
 
   private fun newRecall() =
-    Recall(::RecallId.random(), randomNoms(), createdByUserId, now, firstName, middleNames, lastName, licenceNameCategory = NameFormatCategory.FIRST_MIDDLE_LAST)
+    Recall(
+      ::RecallId.random(),
+      randomNoms(),
+      createdByUserId,
+      now,
+      firstName,
+      middleNames,
+      lastName,
+      croNumber,
+      LocalDate.of(1999, 12, 1),
+      licenceNameCategory = NameFormatCategory.FIRST_MIDDLE_LAST
+    )
 
   private fun recallResponse(recall: Recall, status: Status) =
-    RecallResponse(recall.recallId(), recall.nomsNumber, createdByUserId, now, now, firstName, middleNames, lastName, NameFormatCategory.FIRST_MIDDLE_LAST, status)
+    RecallResponse(
+      recall.recallId(), recall.nomsNumber, createdByUserId, now, now, firstName, middleNames, lastName,
+      croNumber, LocalDate.of(1999, 12, 1), NameFormatCategory.FIRST_MIDDLE_LAST, status
+    )
 
   private val beingBookedOnRecall = newRecall()
   private val bookedOnRecall = newRecall().copy(bookedByUserId = bookedByUserId.value)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/RecallTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/db/RecallTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.AgreeWithRecall
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.NameFormatCategory.FIRST_MIDDLE_LAST
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.NameFormatCategory.OTHER
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Status
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -16,12 +17,21 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class RecallTest {
 
   private val recall = Recall(
-    ::RecallId.random(), NomsNumber("A12345AA"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), MiddleNames("Barnie"), LastName("Badger")
+    ::RecallId.random(),
+    NomsNumber("A12345AA"),
+    ::UserId.random(),
+    OffsetDateTime.now(),
+    FirstName("Barrie"),
+    MiddleNames("Barnie"),
+    LastName("Badger"),
+    CroNumber("ABC/1234A"),
+    LocalDate.of(1999, 12, 1)
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextFactoryTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.PrisonLookupService
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import kotlin.random.Random
 
@@ -40,7 +42,18 @@ class DossierContextFactoryTest {
     val currentPrisonIsWelsh = Random.nextBoolean()
     val document = mockk<Document>()
 
-    val recall = Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"), currentPrison = currentPrison)
+    val recall = Recall(
+      recallId,
+      nomsNumber,
+      ::UserId.random(),
+      OffsetDateTime.now(),
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
+      currentPrison = currentPrison
+    )
 
     every { recallRepository.getByRecallId(recallId) } returns recall
     every { prisonLookupService.getPrisonName(currentPrison) } returns currentPrisonName
@@ -60,7 +73,18 @@ class DossierContextFactoryTest {
     val currentPrisonName = PrisonName("Current Prison Name")
     val currentPrisonIsWelsh = Random.nextBoolean()
 
-    val recall = Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"), currentPrison = currentPrison)
+    val recall = Recall(
+      recallId,
+      nomsNumber,
+      ::UserId.random(),
+      OffsetDateTime.now(),
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
+      currentPrison = currentPrison
+    )
 
     every { recallRepository.getByRecallId(recallId) } returns recall
     every { prisonLookupService.getPrisonName(currentPrison) } returns currentPrisonName

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/DossierContextTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.ProbationInfo
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PersonName
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallLengthDescription
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.fullyPopulatedInstance
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.stream.Stream
 
@@ -36,10 +38,10 @@ class DossierContextTest {
   private val currentPrisonName = PrisonName("Wormwood Rubs")
   private val recall = Recall(
     ::RecallId.random(),
-    nomsNumber, ::UserId.random(), OffsetDateTime.now(), firstName, null, lastName,
+    nomsNumber, ::UserId.random(), OffsetDateTime.now(), firstName, null, lastName, CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1),
+    recallLength = recallLength,
     bookingNumber = bookingNumber,
-    licenceConditionsBreached = licenceConditionsBreached,
-    recallLength = recallLength
+    licenceConditionsBreached = licenceConditionsBreached
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/ReasonsForRecallServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/dossier/ReasonsForRecallServiceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.REASONS
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PdfDecorator
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PdfDocumentGenerationService
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.DocumentService
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class ReasonsForRecallServiceTest {
@@ -44,7 +46,17 @@ class ReasonsForRecallServiceTest {
 
     every { documentService.getLatestVersionedDocumentContentWithCategoryIfExists(any(), REASONS_FOR_RECALL) } returns null
     every { dossierContext.getReasonsForRecallContext() } returns reasonsForRecallContext
-    every { dossierContext.recall } returns Recall(recallId, randomNoms(), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
+    every { dossierContext.recall } returns Recall(
+      recallId,
+      randomNoms(),
+      ::UserId.random(),
+      OffsetDateTime.now(),
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
     every { reasonsForRecallGenerator.generateHtml(reasonsForRecallContext) } returns generatedHtml
     every { pdfDocumentGenerationService.generatePdf(generatedHtml, 1.0, 1.0) } returns Mono.just(expectedPdfBytes)
     every { pdfDecorator.centralHeader(expectedPdfBytes, "OFFICIAL") } returns expectedPdfWithHeaderBytes
@@ -71,7 +83,17 @@ class ReasonsForRecallServiceTest {
     val createdByUserId = ::UserId.random()
 
     every { documentService.getLatestVersionedDocumentContentWithCategoryIfExists(any(), REASONS_FOR_RECALL) } returns expectedBytes
-    every { dossierContext.recall } returns Recall(recallId, randomNoms(), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
+    every { dossierContext.recall } returns Recall(
+      recallId,
+      randomNoms(),
+      ::UserId.random(),
+      OffsetDateTime.now(),
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
 
     val generatedPdf = underTest.getOrGeneratePdf(dossierContext, createdByUserId).block()!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonConfirmationHtmlGenerationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonConfirmationHtmlGenerationTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.HtmlGenerationTestCase
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallLengthDescription
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
@@ -34,7 +35,15 @@ class LetterToPrisonConfirmationHtmlGenerationTest(@Autowired private val templa
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+            ::RecallId.random(),
+            NomsNumber("AA1234A"),
+            ::UserId.random(),
+            OffsetDateTime.now(),
+            FirstName("Barrie"),
+            null,
+            LastName("Badger"),
+            CroNumber("ABC/1234A"),
+            LocalDate.of(1999, 12, 1),
             recallLength = recallLength,
             bookingNumber = "B1234",
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonContextFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonContextFactoryTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallLengthDescription
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -44,9 +45,10 @@ class LetterToPrisonContextFactoryTest {
     val recall = Recall(
       recallId, NomsNumber("AA1234A"), ::UserId.random(),
       OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+      CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1),
+      recallLength = recallLength,
       lastReleasePrison = PrisonId("BOB"),
-      currentPrison = PrisonId("WIM"),
-      recallLength = recallLength
+      currentPrison = PrisonId("WIM")
     )
     val createdByUserDetails = mockk<UserDetails>()
     val currentPrisonName = PrisonName("WIM Prison")
@@ -85,9 +87,10 @@ class LetterToPrisonContextFactoryTest {
     val recall = Recall(
       recallId, NomsNumber("AA1234A"), ::UserId.random(),
       OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+      CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1),
+      recallLength = recallLength,
       lastReleasePrison = PrisonId("BOB"),
-      currentPrison = PrisonId("WIM"),
-      recallLength = recallLength
+      currentPrison = PrisonId("WIM")
     )
     val createdByUserDetails = mockk<UserDetails>()
     val currentPrisonName = PrisonName("WIM Prison")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonCustodyOfficeHtmlGenerationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonCustodyOfficeHtmlGenerationTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.HtmlGenerationTestCase
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallLengthDescription
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
@@ -35,7 +36,15 @@ class LetterToPrisonCustodyOfficeHtmlGenerationTest(@Autowired private val templ
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+            ::RecallId.random(),
+            NomsNumber("AA1234A"),
+            ::UserId.random(),
+            OffsetDateTime.now(),
+            FirstName("Barrie"),
+            null,
+            LastName("Badger"),
+            CroNumber("ABC/1234A"),
+            LocalDate.of(1999, 12, 1),
             recallLength = recallLength,
             contraband = true,
             contrabandDetail = "Because...",
@@ -75,18 +84,26 @@ class LetterToPrisonCustodyOfficeHtmlGenerationTest(@Autowired private val templ
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+            ::RecallId.random(),
+            NomsNumber("AA1234A"),
+            ::UserId.random(),
+            OffsetDateTime.now(),
+            FirstName("Barrie"),
+            null,
+            LastName("Badger"),
+            CroNumber("ABC/1234A"),
+            LocalDate.of(1999, 12, 1),
             recallLength = recallLength,
-            bookingNumber = "B1234",
-            differentNomsNumber = true,
-            differentNomsNumberDetail = "ABC1234F",
-            mappaLevel = MappaLevel.LEVEL_2,
-            additionalLicenceConditions = true,
-            additionalLicenceConditionsDetail = "Blah blah blah",
             contraband = true,
             contrabandDetail = "Because...",
             vulnerabilityDiversity = true,
             vulnerabilityDiversityDetail = "Yes, yadda yadda",
+            mappaLevel = MappaLevel.LEVEL_2,
+            bookingNumber = "B1234",
+            additionalLicenceConditions = true,
+            additionalLicenceConditionsDetail = "Blah blah blah",
+            differentNomsNumber = true,
+            differentNomsNumberDetail = "ABC1234F",
           ),
           FullName("Billie Badger"),
           PrisonName("Prison A"),
@@ -115,7 +132,15 @@ class LetterToPrisonCustodyOfficeHtmlGenerationTest(@Autowired private val templ
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+            ::RecallId.random(),
+            NomsNumber("AA1234A"),
+            ::UserId.random(),
+            OffsetDateTime.now(),
+            FirstName("Barrie"),
+            null,
+            LastName("Badger"),
+            CroNumber("ABC/1234A"),
+            LocalDate.of(1999, 12, 1),
             recallLength = recallLength,
             contraband = true,
             contrabandDetail = "Because...",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonGovernorHtmlGenerationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonGovernorHtmlGenerationTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.HtmlGenerationTestCase
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallLengthDescription
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
@@ -34,7 +35,15 @@ class LetterToPrisonGovernorHtmlGenerationTest(@Autowired private val templateEn
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+            ::RecallId.random(),
+            NomsNumber("AA1234A"),
+            ::UserId.random(),
+            OffsetDateTime.now(),
+            FirstName("Barrie"),
+            null,
+            LastName("Badger"),
+            CroNumber("ABC/1234A"),
+            LocalDate.of(1999, 12, 1),
             recallLength = recallLength,
             lastReleaseDate = LocalDate.of(2020, 10, 1),
             bookingNumber = "B1234"
@@ -66,7 +75,15 @@ class LetterToPrisonGovernorHtmlGenerationTest(@Autowired private val templateEn
       underTest.generateHtml(
         LetterToPrisonContext(
           Recall(
-            ::RecallId.random(), NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+            ::RecallId.random(),
+            NomsNumber("AA1234A"),
+            ::UserId.random(),
+            OffsetDateTime.now(),
+            FirstName("Barrie"),
+            null,
+            LastName("Badger"),
+            CroNumber("ABC/1234A"),
+            LocalDate.of(1999, 12, 1),
             recallLength = recallLength,
             lastReleaseDate = LocalDate.of(2020, 10, 1),
             bookingNumber = "B1234"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonServiceParameterizedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/lettertoprison/LetterToPrisonServiceParameterizedTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PdfDecorator
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PdfDocumentGenerationService
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallImage.HmppsLogo
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallLengthDescription
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
@@ -78,7 +79,18 @@ internal class LetterToPrisonServiceParameterizedTest {
   @ParameterizedTest
   @MethodSource("letterToPrisonParameters")
   fun `generates a letter to prison for a recall `(recallLength: RecallLength, annexHeaderText: String) {
-    val aRecall = Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"), recallLength = recallLength)
+    val aRecall = Recall(
+      recallId,
+      nomsNumber,
+      ::UserId.random(),
+      OffsetDateTime.now(),
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
+      recallLength = recallLength
+    )
     val documentId = ::DocumentId.random()
     val assessor = UserDetails(
       ::UserId.random(),
@@ -128,7 +140,13 @@ internal class LetterToPrisonServiceParameterizedTest {
       )
     } returns mergedNumberedBytes
     every {
-      documentService.storeDocument(recallId, createdByUserId, mergedNumberedBytes, LETTER_TO_PRISON, "LETTER_TO_PRISON.pdf")
+      documentService.storeDocument(
+        recallId,
+        createdByUserId,
+        mergedNumberedBytes,
+        LETTER_TO_PRISON,
+        "LETTER_TO_PRISON.pdf"
+      )
     } returns documentId
 
     val result = underTest.generateAndStorePdf(recallId, createdByUserId, null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextFactoryTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.SentencingInfo
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -86,11 +87,13 @@ class RecallNotificationContextFactoryTest {
       nomsNumber,
       ::UserId.random(),
       OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
       lastReleasePrison = lastReleasePrisonId,
-      sentencingInfo = sentencingInfo,
-      currentPrison = currentPrisonId,
       localPoliceForceId = localPoliceForceId,
-      inCustody = true
+      inCustody = true,
+      sentencingInfo = sentencingInfo,
+      currentPrison = currentPrisonId
     )
     val userDetails = mockk<UserDetails>()
     val document = mockk<Document>()
@@ -135,11 +138,13 @@ class RecallNotificationContextFactoryTest {
       nomsNumber,
       ::UserId.random(),
       OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
       lastReleasePrison = lastReleasePrisonId,
-      sentencingInfo = sentencingInfo,
-      currentPrison = currentPrisonId,
       localPoliceForceId = localPoliceForceId,
-      inCustody = true
+      inCustody = true,
+      sentencingInfo = sentencingInfo,
+      currentPrison = currentPrisonId
     )
     val userDetails = mockk<UserDetails>()
 
@@ -194,10 +199,19 @@ class RecallNotificationContextFactoryTest {
       SentencingInfo(LocalDate.now(), LocalDate.now(), LocalDate.now(), sentencingCourtId, "", SentenceLength(3, 1, 0))
     val localPoliceForceId = PoliceForceId("XYZ")
     val recall = Recall(
-      recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), FirstName("Andy"), MiddleNames("Bertie"), LastName("Badger"),
+      recallId,
+      nomsNumber,
+      ::UserId.random(),
+      OffsetDateTime.now(),
+      FirstName("Andy"),
+      MiddleNames("Bertie"),
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
       lastReleasePrison = lastReleasePrisonId,
       lastReleaseDate = LocalDate.now(),
       localPoliceForceId = localPoliceForceId,
+      inCustody = false,
       contraband = true,
       vulnerabilityDiversity = true,
       mappaLevel = MappaLevel.LEVEL_2,
@@ -207,7 +221,6 @@ class RecallNotificationContextFactoryTest {
       currentPrison = currentPrisonId,
       previousConvictionMainNameCategory = prevConsMainNameCategory,
       previousConvictionMainName = prevConsMainName,
-      inCustody = false,
       arrestIssues = false
     )
     val userDetails =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/documents/recallnotification/RecallNotificationContextTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.documents.PersonName
 import uk.gov.justice.digital.hmpps.managerecallsapi.documents.RecallLengthDescription
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtName
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FullName
@@ -53,10 +54,19 @@ class RecallNotificationContextTest {
   private val probationOfficerName = "Mr Probation Officer"
 
   private val recall = Recall(
-    recallId, NomsNumber("AA1234A"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"),
+    recallId,
+    NomsNumber("AA1234A"),
+    ::UserId.random(),
+    OffsetDateTime.now(),
+    FirstName("Barrie"),
+    null,
+    LastName("Badger"),
+    CroNumber("ABC/1234A"),
+    LocalDate.of(1999, 12, 1),
     recallLength = recallLength,
     lastReleaseDate = lastReleaseDate,
     localPoliceForceId = PoliceForceId("metropolitan"),
+    inCustody = true,
     contraband = true,
     contrabandDetail = "I believe that they will bring contraband to prison",
     vulnerabilityDiversity = true,
@@ -81,8 +91,7 @@ class RecallNotificationContextTest {
     reasonsForRecall = setOf(ELM_FURTHER_OFFENCE),
     previousConvictionMainNameCategory = NameFormatCategory.OTHER,
     previousConvictionMainName = "Bryan Badger",
-    assessedByUserId = userId,
-    inCustody = true
+    assessedByUserId = userId
   )
 
   private val prisoner = Prisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/DocumentRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/DocumentRepositoryIntegrationTest.kt
@@ -4,7 +4,6 @@ import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.startsWith
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -14,23 +13,12 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.WrongDocumentTypeException
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Document
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetailsRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
-import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomUnVersionedDocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomVersionedDocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.service.DocumentNotFoundException
@@ -42,41 +30,13 @@ import javax.transaction.Transactional
 @ActiveProfiles("db-test")
 class DocumentRepositoryIntegrationTest(
   @Autowired private val documentRepository: DocumentRepository,
-  @Autowired private val recallRepository: RecallRepository,
-  @Autowired private val userDetailsRepository: UserDetailsRepository
-) {
+) : IntegrationTestBase() {
 
-  private val recallId = ::RecallId.random()
-  private val createdByUserId = ::UserId.random()
-  private val nomsNumber = randomNoms()
-  private val recall = Recall(recallId, nomsNumber, createdByUserId, OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
   private val documentId = ::DocumentId.random()
   // TODO: parameterized tests driven from RecallDocumentCategory
   private val versionedCategory = randomVersionedDocumentCategory()
   private val unVersionedCategory = randomUnVersionedDocumentCategory()
   private val versionedRecallDocument = versionedDocument(documentId, recallId, versionedCategory, 1)
-  private val currentUserId = ::UserId.random()
-
-  @BeforeEach
-  fun `setup createdBy user`() {
-    createUserDetails(createdByUserId)
-    createUserDetails(currentUserId)
-  }
-
-  private fun createUserDetails(userId: UserId) {
-    userDetailsRepository.save(
-      UserDetails(
-        userId,
-        FirstName("Test"),
-        LastName("User"),
-        "",
-        Email("test@user.com"),
-        PhoneNumber("09876543210"),
-        CaseworkerBand.FOUR_PLUS,
-        OffsetDateTime.now()
-      )
-    )
-  }
 
   // Note: when using @Transactional to clean up after the tests we need to 'flush' to trigger the DB constraints, hence use of saveAndFlush()
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/IntegrationTestBase.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetailsRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -22,6 +23,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 @ExtendWith(SpringExtension::class)
@@ -33,7 +35,17 @@ abstract class IntegrationTestBase {
   final val createdByUserId = ::UserId.random()
   val currentUserId = ::UserId.random()
   final val nomsNumber = randomNoms()
-  val recall = Recall(recallId, nomsNumber, createdByUserId, OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
+  val recall = Recall(
+    recallId,
+    nomsNumber,
+    createdByUserId,
+    OffsetDateTime.now(),
+    FirstName("Barrie"),
+    null,
+    LastName("Badger"),
+    CroNumber("ABC/1234A"),
+    LocalDate.of(1999, 12, 1)
+  )
 
   @Autowired
   protected lateinit var userDetailsRepository: UserDetailsRepository
@@ -50,7 +62,7 @@ abstract class IntegrationTestBase {
     createUserDetails(currentUserId)
   }
 
-  private fun createUserDetails(userId: UserId) {
+  protected fun createUserDetails(userId: UserId) {
     userDetailsRepository.save(
       UserDetails(
         userId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/MissingDocumentsRecordRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/MissingDocumentsRecordRepositoryIntegrationTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.managerecallsapi.integration.db
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.startsWith
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -12,25 +11,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Document
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.MissingDocumentsRecord
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.MissingDocumentsRecordRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetailsRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.MissingDocumentsRecordId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
-import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomVersionedDocumentCategory
 import java.time.OffsetDateTime
 import javax.transaction.Transactional
@@ -41,39 +28,11 @@ import javax.transaction.Transactional
 class MissingDocumentsRecordRepositoryIntegrationTest(
   @Autowired private val missingDocumentsRecordRepository: MissingDocumentsRecordRepository,
   @Autowired private val documentRepository: DocumentRepository,
-  @Autowired private val recallRepository: RecallRepository,
-  @Autowired private val userDetailsRepository: UserDetailsRepository
-) {
+) : IntegrationTestBase() {
 
-  private val recallId = ::RecallId.random()
-  private val createdByUserId = ::UserId.random()
-  private val currentUserId = ::UserId.random()
-  private val nomsNumber = randomNoms()
-  private val recall = Recall(recallId, nomsNumber, createdByUserId, OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
   private val documentId = ::DocumentId.random()
   // TODO: parameterized tests driven from RecallDocumentCategory
   private val versionedCategory = randomVersionedDocumentCategory()
-
-  @BeforeEach
-  fun `setup createdBy user`() {
-    createUserDetails(createdByUserId)
-    createUserDetails(currentUserId)
-  }
-
-  private fun createUserDetails(userId: UserId) {
-    userDetailsRepository.save(
-      UserDetails(
-        userId,
-        FirstName("Test"),
-        LastName("User"),
-        "",
-        Email("test@user.com"),
-        PhoneNumber("09876543210"),
-        CaseworkerBand.FOUR_PLUS,
-        OffsetDateTime.now()
-      )
-    )
-  }
 
   // Note: when using @Transactional to clean up after the tests we need to 'flush' to trigger the DB constraints, hence use of saveAndFlush()
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/RecallReasonAuditRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/RecallReasonAuditRepositoryIntegrationTest.kt
@@ -5,7 +5,6 @@ import com.natpryce.hamkrest.equalTo
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -17,22 +16,9 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.ReasonForRecall.
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.ReasonForRecall.ELM_EQUIPMENT_TAMPER
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.ReasonForRecall.ELM_FURTHER_OFFENCE
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.ReasonForRecall.OTHER
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.JpaRecallReasonAuditRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.JpaRecallRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallReasonAuditRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
-import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomNoms
 import java.sql.Timestamp
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -45,38 +31,8 @@ import javax.transaction.Transactional
 class RecallReasonAuditRepositoryIntegrationTest(
   @Qualifier("jpaRecallReasonAuditRepository") @Autowired private val jpaRepository: JpaRecallReasonAuditRepository,
   @Qualifier("jpaRecallRepository") @Autowired private val jpaRecallRepository: JpaRecallRepository,
-  @Autowired private val userDetailsRepository: UserDetailsRepository
-) {
-  private val nomsNumber = randomNoms()
-  private val createdByUserId = ::UserId.random()
-  private val recallId = ::RecallId.random()
-  private val now = OffsetDateTime.now()
-  private val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
-  private val currentUserId = ::UserId.random()
-
+) : IntegrationTestBase() {
   private val underTest = RecallReasonAuditRepository(jpaRepository)
-  private val recallRepository = RecallRepository(jpaRecallRepository)
-
-  @BeforeEach
-  fun `setup createdBy user`() {
-    createUserDetails(currentUserId)
-    createUserDetails(createdByUserId)
-  }
-
-  private fun createUserDetails(userId: UserId) {
-    userDetailsRepository.save(
-      UserDetails(
-        userId,
-        FirstName("Test"),
-        LastName("User"),
-        "",
-        Email("test@user.com"),
-        PhoneNumber("09876543210"),
-        CaseworkerBand.FOUR_PLUS,
-        OffsetDateTime.now()
-      )
-    )
-  }
 
   @Test
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/RecallRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/db/RecallRepositoryIntegrationTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.managerecallsapi.integration.db
 import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -13,21 +12,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallSearchRequest
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.CaseworkerBand
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Document
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.PART_A_RECALL_REPORT
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.JpaDocumentRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.JpaRecallRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetails
-import uk.gov.justice.digital.hmpps.managerecallsapi.db.UserDetailsRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.Email
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
@@ -43,39 +34,11 @@ import javax.transaction.Transactional
 class RecallRepositoryIntegrationTest(
   @Qualifier("jpaRecallRepository") @Autowired private val jpaRepository: JpaRecallRepository,
   @Qualifier("jpaDocumentRepository") @Autowired private val jpaDocumentRepository: JpaDocumentRepository,
-  @Autowired private val userDetailsRepository: UserDetailsRepository
-) {
-  private val nomsNumber = randomNoms()
-  private val createdByUserId = ::UserId.random()
-  private val recallId = ::RecallId.random()
-  private val now = OffsetDateTime.now()
-  private val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
-  private val details = "Some string"
-  private val currentUserId = ::UserId.random()
-
+) : IntegrationTestBase() {
   private val repository = RecallRepository(jpaRepository)
   private val documentRepository = DocumentRepository(jpaDocumentRepository)
 
-  @BeforeEach
-  fun `setup createdBy user`() {
-    createUserDetails(currentUserId)
-    createUserDetails(createdByUserId)
-  }
-
-  private fun createUserDetails(userId: UserId) {
-    userDetailsRepository.save(
-      UserDetails(
-        userId,
-        FirstName("Test"),
-        LastName("User"),
-        "",
-        Email("test@user.com"),
-        PhoneNumber("09876543210"),
-        CaseworkerBand.FOUR_PLUS,
-        OffsetDateTime.now()
-      )
-    )
-  }
+  private val details = "Some string"
 
   @Test
   @Transactional
@@ -173,7 +136,7 @@ class RecallRepositoryIntegrationTest(
       "PART_A.pdf",
       1,
       details,
-      now,
+      OffsetDateTime.now(),
       createdByUserId
     )
     val recallToUpdate = recall.copy(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/DossierGenerationGotenbergComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/DossierGenerationGotenbergComponentTest.kt
@@ -8,11 +8,13 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.LocalDeliveryUni
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Pdf
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.DOSSIER
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.RECALL_NOTIFICATION
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonId
 import uk.gov.justice.digital.hmpps.managerecallsapi.matchers.hasNumberOfPages
+import java.time.LocalDate
 
 class DossierGenerationGotenbergComponentTest : GotenbergComponentTestBase() {
 
@@ -41,7 +43,16 @@ class DossierGenerationGotenbergComponentTest : GotenbergComponentTestBase() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
 
     val recall =
-      authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger")))
+      authenticatedClient.bookRecall(
+        BookRecallRequest(
+          nomsNumber,
+          FirstName("Barrie"),
+          null,
+          LastName("Badger"),
+          CroNumber("1234/56A"),
+          LocalDate.now()
+        )
+      )
     updateRecallWithRequiredInformationForTheDossier(
       recall.recallId,
       localDeliveryUnit = localDeliveryUnit,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/LetterToPrisonGotenbergComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/LetterToPrisonGotenbergComponentTest.kt
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Pdf
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.LETTER_TO_PRISON
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import uk.gov.justice.digital.hmpps.managerecallsapi.matchers.hasNumberOfPages
+import java.time.LocalDate
 
 class LetterToPrisonGotenbergComponentTest : GotenbergComponentTestBase() {
 
@@ -24,7 +26,16 @@ class LetterToPrisonGotenbergComponentTest : GotenbergComponentTestBase() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
     setupUserDetailsFor(assessedByUserId)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger")))
+    val recall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName("Barrie"),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     updateRecallWithRequiredInformationForTheLetterToPrison(
       recall.recallId,
       assessedByUserId = assessedByUserId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/RecallNotificationGotenbergComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/RecallNotificationGotenbergComponentTest.kt
@@ -7,12 +7,14 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallReques
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.LocalDeliveryUnit
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Pdf
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.RECALL_NOTIFICATION
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonId
 import uk.gov.justice.digital.hmpps.managerecallsapi.matchers.hasNumberOfPages
 import uk.gov.justice.digital.hmpps.managerecallsapi.matchers.hasTotalPageCount
+import java.time.LocalDate
 
 class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
 
@@ -25,7 +27,16 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
   fun `can generate a recall notification`() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger")))
+    val recall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName("Barrie"),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     updateRecallWithRequiredInformationForTheDossier(
       recall.recallId,
       localDeliveryUnit = LocalDeliveryUnit.ISLE_OF_MAN,
@@ -35,7 +46,7 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
     val recallNotificationId = authenticatedClient.generateDocument(recall.recallId, RECALL_NOTIFICATION)
     val recallNotification = authenticatedClient.getDocument(recall.recallId, recallNotificationId.documentId)
 
-//    writeBase64EncodedStringToFile("recall-notification.pdf", recallNotification.content)
+    writeBase64EncodedStringToFile("recall-notification.pdf", recallNotification.content)
     assertThat(Pdf(recallNotification.content), hasNumberOfPages(equalTo(3)))
     assertThat(Pdf(recallNotification.content), hasTotalPageCount(3))
   }
@@ -44,7 +55,16 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
   fun `can generate a not in custody recall notification`() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger")))
+    val recall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName("Barrie"),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     updateRecallWithRequiredInformationForTheDossier(
       recall.recallId,
       localDeliveryUnit = LocalDeliveryUnit.ISLE_OF_MAN,
@@ -55,7 +75,7 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
     val recallNotificationId = authenticatedClient.generateDocument(recall.recallId, RECALL_NOTIFICATION)
     val recallNotification = authenticatedClient.getDocument(recall.recallId, recallNotificationId.documentId)
 
-    // writeBase64EncodedStringToFile("recall-notification-nic.pdf", recallNotification.content)
+    writeBase64EncodedStringToFile("recall-notification-nic.pdf", recallNotification.content)
     assertThat(Pdf(recallNotification.content), hasNumberOfPages(equalTo(5)))
     assertThat(Pdf(recallNotification.content), hasTotalPageCount(5))
   }
@@ -64,7 +84,16 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
   fun `recall notification with a long recall summary`() {
     expectAPrisonerWillBeFoundFor(nomsNumber, prisonerFirstName)
 
-    val recall = authenticatedClient.bookRecall(BookRecallRequest(nomsNumber, FirstName("Barrie"), null, LastName("Badger")))
+    val recall = authenticatedClient.bookRecall(
+      BookRecallRequest(
+        nomsNumber,
+        FirstName("Barrie"),
+        null,
+        LastName("Badger"),
+        CroNumber("1234/56A"),
+        LocalDate.now()
+      )
+    )
     updateRecallWithRequiredInformationForTheDossier(
       recall.recallId,
       contraband = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/DocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/DocumentServiceTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory.UNCATEG
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.Recall
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.DocumentId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
@@ -39,6 +40,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.service.VirusScanResult.Vir
 import uk.gov.justice.digital.hmpps.managerecallsapi.storage.S3Service
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.util.UUID
@@ -64,7 +66,17 @@ internal class DocumentServiceTest {
   private val documentBytes = randomString().toByteArray()
   private val nomsNumber = NomsNumber("A1235B")
   private val aRecallWithoutDocuments =
-    Recall(recallId, nomsNumber, ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
+    Recall(
+      recallId,
+      nomsNumber,
+      ::UserId.random(),
+      OffsetDateTime.now(),
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1)
+    )
   private val documentCategory = PART_A_RECALL_REPORT
   private val fileName = randomString()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.db.RecallRepository
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.SentenceLength
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.SentencingInfo
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtId
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
@@ -46,7 +47,17 @@ class RecallServiceTest {
   private val underTest = RecallService(recallRepository, bankHolidayService, fixedClock)
 
   private val recallId = ::RecallId.random()
-  private val existingRecall = Recall(recallId, NomsNumber("A9876ZZ"), ::UserId.random(), OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"))
+  private val existingRecall = Recall(
+    recallId,
+    NomsNumber("A9876ZZ"),
+    ::UserId.random(),
+    OffsetDateTime.now(),
+    FirstName("Barrie"),
+    null,
+    LastName("Badger"),
+    CroNumber("ABC/1234A"),
+    LocalDate.of(1999, 12, 1)
+  )
   private val today = LocalDate.now()
   private val currentUserId = ::UserId.random()
 
@@ -219,9 +230,21 @@ class RecallServiceTest {
     val now = OffsetDateTime.now()
     val createdByUserId = ::UserId.random()
 
-    val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
+    val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"), CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1))
     val assignee = ::UserId.random()
-    val expected = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"), lastUpdatedDateTime = OffsetDateTime.now(fixedClock), assignee = assignee)
+    val expected = Recall(
+      recallId,
+      nomsNumber,
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
+      lastUpdatedDateTime = OffsetDateTime.now(fixedClock),
+      assignee = assignee
+    )
 
     every { recallRepository.getByRecallId(recallId) } returns recall
     every { recallRepository.save(expected, currentUserId) } returns expected
@@ -235,11 +258,22 @@ class RecallServiceTest {
     val nomsNumber = randomNoms()
     val now = OffsetDateTime.now()
     val createdByUserId = ::UserId.random()
-    val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"))
+    val recall = Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"), CroNumber("ABC/1234A"), LocalDate.of(1999, 12, 1))
     val assignee = ::UserId.random()
     val expected = recall.copy(lastUpdatedDateTime = OffsetDateTime.now(fixedClock))
 
-    every { recallRepository.getByRecallId(recallId) } returns Recall(recallId, nomsNumber, createdByUserId, now, FirstName("Barrie"), null, LastName("Badger"), assignee = assignee)
+    every { recallRepository.getByRecallId(recallId) } returns Recall(
+      recallId,
+      nomsNumber,
+      createdByUserId,
+      now,
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
+      assignee = assignee
+    )
     every { recallRepository.save(expected, currentUserId) } returns expected
 
     val assignedRecall = underTest.unassignRecall(recallId, assignee, currentUserId)
@@ -254,7 +288,18 @@ class RecallServiceTest {
     val nomsNumber = randomNoms()
     val createdByUserId = ::UserId.random()
 
-    every { recallRepository.getByRecallId(recallId) } returns Recall(recallId, nomsNumber, createdByUserId, OffsetDateTime.now(), FirstName("Barrie"), null, LastName("Badger"), assignee = assignee)
+    every { recallRepository.getByRecallId(recallId) } returns Recall(
+      recallId,
+      nomsNumber,
+      createdByUserId,
+      OffsetDateTime.now(),
+      FirstName("Barrie"),
+      null,
+      LastName("Badger"),
+      CroNumber("ABC/1234A"),
+      LocalDate.of(1999, 12, 1),
+      assignee = assignee
+    )
 
     assertThrows<NotFoundException> { underTest.unassignRecall(recallId, otherAssignee, currentUserId) }
   }


### PR DESCRIPTION
Currently we just store and return them, not using them until we have updated database values (manual update to prod)