### PR TITLE
Set resource requests for Gotenberg.

### DIFF
--- a/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/deployment.yaml
+++ b/helm_deploy/manage-recalls-api/subcharts/gotenberg/templates/deployment.yaml
@@ -60,3 +60,7 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 30
             failureThreshold: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 200Mi


### PR DESCRIPTION
This increases the default requests for CPU/RAM in gotenberg from:

- CPU: 10m -> 50m
- RAM: 100Mi -> 200Mi

The limits remain the same as before.