### PR TITLE
TECH: remove all forced versions for OWASP/CVEs plus minor uplifts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.3-beta"
-  kotlin("plugin.spring") version "1.5.10"
+  kotlin("plugin.spring") version "1.5.21"
   kotlin("plugin.jpa") version "1.5.20"
   kotlin("plugin.serialization") version "1.4.31"
   id("org.owasp.dependencycheck") version "6.5.0.1"
@@ -21,13 +21,6 @@ configurations {
 dependencyCheck {
   suppressionFiles.add("$rootDir/owasp.suppression.xml")
 }
-
-// Force log4j2.version to 2.17.1 for CVE-2021-44832
-project.extensions.extraProperties["log4j2.version"] = "2.17.1"
-// Force logback.version to 1.2.9 (latest stable) for CVE-2021-42550
-project.extensions.extraProperties["logback.version"] = "1.2.9"
-// Force uplift thymeleaf for CVE-2021-43466
-project.extensions.extraProperties["thymeleaf.version"] = "3.0.14.RELEASE"
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-actuator:2.6.2")

--- a/helm_deploy/manage-recalls-api/Chart.yaml
+++ b/helm_deploy/manage-recalls-api/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     version: 1.1.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.2.8
+    version: 0.3.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: clamav
     version: 0.1.6


### PR DESCRIPTION
TECH: remove all forced versions for OWASP/CVEs plus minor uplifts - read-back from recent changes in `legacy-ppud-api`.  Passes local "./gradlew dependencyCheckAnalyze".