### PR TITLE
PUD-1377: Switch the actuator endpoints onto a private port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ ecr.repo
 # generated test files
 *.actual
 *.pdf
+
+# helm files (generated when developing)
+helm_deploy/manage-recalls-api/Chart.lock
+helm_deploy/manage-recalls-api/charts/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,6 @@ COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 
 USER 2000
+EXPOSE 8080 8081
 
 ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]

--- a/helm_deploy/manage-recalls-api/Chart.yaml
+++ b/helm_deploy/manage-recalls-api/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.1.0
     repository: file://subcharts/gotenberg
   - name: generic-service
-    version: 1.1.2
+    version: 1.2.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 0.3.0

--- a/helm_deploy/manage-recalls-api/values.yaml
+++ b/helm_deploy/manage-recalls-api/values.yaml
@@ -18,6 +18,14 @@ generic-service:
     annotations:
       external-dns.alpha.kubernetes.io/aws-weight: "100"
 
+  livenessProbe:
+    httpGet:
+      path: /health/liveness
+      port: metrics
+  readinessProbe:
+    httpGet:
+      path: /health/readiness
+      port: metrics
 
   env:
     JAVA_OPTS: "-Xmx512m"
@@ -39,6 +47,7 @@ generic-service:
     enabled: true
     scrapeInterval: 15s
     metricsPath: /prometheus
+    metricsPort: 8081
 
 generic-prometheus-alerts:
   targetApplication: manage-recalls-api

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthController.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthController() {
+  @GetMapping("/health")
+  fun getHealth(): ResponseEntity<String> = ResponseEntity.ok("OK")
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,9 +65,8 @@ server:
     include-message: always
 
 management:
-#  TODO: PUD-1377 - do not expose the metrics and health endpoints publicly.
-#  server:
-#    port: 8081
+  server:
+    port: 8081
   endpoints:
     enabled-by-default: false
     web:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/health/HealthCheckComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/health/HealthCheckComponentTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.OK
@@ -21,8 +22,8 @@ import java.util.stream.Stream
 @ActiveProfiles("db-test-no-clam")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @AutoConfigureWebTestClient(timeout = "15000")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = ["management.server.port=9999", "server.port=9999"])
 class HealthCheckComponentTest : ComponentTestBase() {
-
   @Test
   fun `healthy service returns status of each health check and version details`() {
     prisonerOffenderSearchMockServer.isHealthy()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/health/InfoComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/health/InfoComponentTest.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.managerecallsapi.component.health
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.justice.digital.hmpps.managerecallsapi.component.ComponentTestBase
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter.ISO_DATE
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = ["management.server.port=9998", "server.port=9998"])
 class InfoComponentTest : ComponentTestBase() {
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthControllerTest.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.managerecallsapi.controller
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+class HealthControllerTest {
+  private val underTest = HealthController()
+
+  @Test
+  fun `getHealth returns OK`() {
+    val results = underTest.getHealth()
+
+    assertThat(results.statusCodeValue, equalTo(200))
+    assertThat(results.body, equalTo("OK"))
+  }
+}


### PR DESCRIPTION
This hides away all the actuator endpoints (health, info, prometheus)
from public view and onto port 8081.

I've added in an extra `healthController` to allow external tests
(pingdom) to still check the health of the API.