### PR TITLE
Allow network ingress from the `manage-recalls-dev` namespace

### DIFF
--- a/helm_deploy/manage-recalls-api/templates/networkpolicy-ppud-replacement-ingess.yaml
+++ b/helm_deploy/manage-recalls-api/templates/networkpolicy-ppud-replacement-ingess.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-ppud-replacement-ingress
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            component: ppud-replacement-dev


### PR DESCRIPTION
This is so that the dashboards app can get the current version of the
application - this is now only available internally to the cluster.