### PR TITLE
Make the `/health` endpoint return JSON.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthController.kt
@@ -1,11 +1,19 @@
 package uk.gov.justice.digital.hmpps.managerecallsapi.controller
 
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
 class HealthController() {
   @GetMapping("/health")
-  fun getHealth(): ResponseEntity<String> = ResponseEntity.ok("OK")
+  @ResponseStatus(HttpStatus.OK)
+  fun getHealth(): Map<String, String> =
+    hashMapOf(
+      "Status" to "UP"
+    )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthControllerTest.kt
@@ -9,9 +9,11 @@ class HealthControllerTest {
 
   @Test
   fun `getHealth returns OK`() {
-    val results = underTest.getHealth()
+    val result = underTest.getHealth()
+    val expected = hashMapOf(
+      "Status" to "UP"
+    )
 
-    assertThat(results.statusCodeValue, equalTo(200))
-    assertThat(results.body, equalTo("OK"))
+    assertThat(result, equalTo(expected))
   }
 }


### PR DESCRIPTION
This is just to make it consistent with everything else and to also make
it easier to test on the UI end.