### PR TITLE
Add the version and buildUrl to external `/health`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthController.kt
@@ -14,6 +14,14 @@ class HealthController() {
   @ResponseStatus(HttpStatus.OK)
   fun getHealth(): Map<String, String> =
     hashMapOf(
-      "status" to "UP"
+      "status" to "UP",
+      "version" to version(),
+      "buildUrl" to buildUrl()
     )
+
+  private
+
+  fun version(): String = System.getenv("BUILD_NUMBER") ?: "app_version"
+
+  fun buildUrl(): String = System.getenv("BUILD_URL") ?: "https://example.com"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/HealthControllerTest.kt
@@ -11,7 +11,9 @@ class HealthControllerTest {
   fun `getHealth returns OK`() {
     val result = underTest.getHealth()
     val expected = hashMapOf(
-      "status" to "UP"
+      "status" to "UP",
+      "version" to "app_version",
+      "buildUrl" to "https://example.com"
     )
 
     assertThat(result, equalTo(expected))


### PR DESCRIPTION
This endpoint is used to report the version tested in the E2E tests so
it needs this info in it.