### PR TITLE
Initialise the rtcCounter on start

### DIFF
--- a/helm_deploy/manage-recalls-api/templates/dashboards.yaml
+++ b/helm_deploy/manage-recalls-api/templates/dashboards.yaml
@@ -192,7 +192,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "HTTP Request Rate (rpm)",
+          "title": "HTTP Request Rate",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,7 +2,7 @@
 # Per environment values which override defaults in manage-recalls-api/values.yaml
 
 generic-service:
-  replicaCount: 4
+  replicaCount: 2
 
   ingress:
     host: manage-recalls-api-dev.hmpps.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallService.kt
@@ -44,7 +44,7 @@ class RecallService(
     val SYSTEM_USER_ID = UserId(UUID.fromString("99999999-9999-9999-9999-999999999999"))
   }
 
-  private var rtcCounter: Counter? = null
+  private var rtcCounter: Counter = meterRegistry.counter("autoReturnedToCustody")
   private val log = LoggerFactory.getLogger(this::class.java)
 
   @Transactional
@@ -166,16 +166,9 @@ class RecallService(
         val returnedToCustodyDateTime = movements[it.nomsNumber]!!.movementDateTime()
         log.info("Returning ${it.recallId()} to custody as of $returnedToCustodyDateTime")
         returnedToCustody(it, returnedToCustodyDateTime, OffsetDateTime.now(clock), SYSTEM_USER_ID)
-        getCounter().increment()
+        rtcCounter.increment()
       }
     }
-  }
-
-  private fun getCounter(): Counter {
-    if (rtcCounter == null) {
-      rtcCounter = meterRegistry.counter("autoReturnedToCustody")
-    }
-    return rtcCounter!!
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceParameterisedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceParameterisedTest.kt
@@ -46,7 +46,7 @@ class RecallServiceParameterisedTest {
   private val fixedClock = Clock.fixed(Instant.parse("2021-10-04T13:15:50.00Z"), ZoneId.of("UTC"))
   private val returnToCustodyUpdateThresholdMinutes = 60L
 
-  private var underTest = mockk<RecallService>()
+  private lateinit var underTest: RecallService
 
   private val recallId = ::RecallId.random()
   private val existingRecall = Recall(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RecallServiceTest.kt
@@ -60,7 +60,7 @@ class RecallServiceTest {
   private val fixedClock = Clock.fixed(Instant.parse("2021-10-04T13:15:50.00Z"), ZoneId.of("UTC"))
   private val returnToCustodyUpdateThresholdMinutes = 60L
 
-  private var underTest = mockk<RecallService>()
+  private lateinit var underTest: RecallService
 
   private val recallId = ::RecallId.random()
   private val existingRecall = Recall(


### PR DESCRIPTION
The lazy initialisation of the counter wasn't giving us a default zero
counter on application load, this change fixes that.