### PR TITLE
PUD-1197: Add metrics for timeout errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/BankHolidayRegisterClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/BankHolidayRegisterClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.managerecallsapi.register
 
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.ParameterizedTypeReference
@@ -11,8 +12,10 @@ import java.time.LocalDate
 @Component
 class BankHolidayRegisterClient(
   @Autowired internal val bankHolidayRegisterWebClient: WebClient,
-  @Value("\${clientApi.timeout}") val timeout: Long
-) : ErrorHandlingClient(bankHolidayRegisterWebClient, timeout) {
+  @Value("\${bankHolidayRegister.endpoint.url}") val bankHolidayRegisterEndpointUrl: String,
+  @Value("\${clientApi.timeout}") val timeout: Long,
+  @Autowired private val meterRegistry: MeterRegistry,
+) : ErrorHandlingClient(bankHolidayRegisterWebClient, bankHolidayRegisterEndpointUrl, timeout, meterRegistry) {
   // Note: no mock implementation: real is used also for all tests; likely responses will be cached in future anyway
 
   fun getBankHolidays(): Mono<List<BankHoliday>> =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/CourtRegisterClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/CourtRegisterClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.managerecallsapi.register
 
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.ParameterizedTypeReference
@@ -12,8 +13,10 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CourtName
 @Component
 class CourtRegisterClient(
   @Autowired internal val courtRegisterWebClient: WebClient,
-  @Value("\${clientApi.timeout}") val timeout: Long
-) : ErrorHandlingClient(courtRegisterWebClient, timeout) {
+  @Value("\${courtRegister.endpoint.url}") val courtRegisterEndpointUrl: String,
+  @Value("\${clientApi.timeout}") val timeout: Long,
+  @Autowired private val meterRegistry: MeterRegistry,
+) : ErrorHandlingClient(courtRegisterWebClient, courtRegisterEndpointUrl, timeout, meterRegistry) {
 
   fun getAllCourts(): Mono<List<Court>> =
     getResponse("/courts/all", object : ParameterizedTypeReference<List<Court>>() {})

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/ErrorHandlingClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/ErrorHandlingClient.kt
@@ -1,17 +1,22 @@
 package uk.gov.justice.digital.hmpps.managerecallsapi.register
 
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tags
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.ClientException
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.ClientTimeoutException
+import java.net.URI
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 
 abstract class ErrorHandlingClient(
   val webClient: WebClient,
-  private val clientTimeout: Long
+  private val endpointUrl: String,
+  private val clientTimeout: Long,
+  private val meterRegistry: MeterRegistry
 ) {
 
   fun <T> getResponse(uri: String, typeReference: ParameterizedTypeReference<T>): Mono<T> {
@@ -40,5 +45,8 @@ abstract class ErrorHandlingClient(
     .retrieve()
     .bodyToMono(value)
     .timeout(Duration.ofSeconds(clientTimeout))
-    .onErrorMap(TimeoutException::class.java) { ex -> ClientTimeoutException(this.javaClass.simpleName, ex.javaClass.canonicalName) }
+    .onErrorMap(TimeoutException::class.java) { ex ->
+      meterRegistry.counter("http_client_requests_timeout", Tags.of("clientName", URI(endpointUrl).host)).increment()
+      ClientTimeoutException(this.javaClass.simpleName, ex.javaClass.canonicalName)
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/PoliceUkApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/PoliceUkApiClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.managerecallsapi.register
 
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.ParameterizedTypeReference
@@ -12,8 +13,10 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PoliceForceId
 @Component
 class PoliceUkApiClient(
   @Autowired internal val policeUkApiWebClient: WebClient,
-  @Value("\${clientApi.timeout}") val timeout: Long
-) : ErrorHandlingClient(policeUkApiWebClient, timeout) {
+  @Value("\${policeUkApi.endpoint.url}") val policeUkApiEndpointUrl: String,
+  @Value("\${clientApi.timeout}") val timeout: Long,
+  @Autowired private val meterRegistry: MeterRegistry,
+) : ErrorHandlingClient(policeUkApiWebClient, policeUkApiEndpointUrl, timeout, meterRegistry) {
   // As critical Recall data we likely should have more robust access than calling out everytime to a public website,
   // e.g. caching the responses locally, perhaps introducing a boolean active property etc.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/PrisonRegisterClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/register/PrisonRegisterClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.managerecallsapi.register
 
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.ParameterizedTypeReference
@@ -12,8 +13,10 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PrisonId
 @Component
 class PrisonRegisterClient(
   @Autowired private val prisonRegisterWebClient: WebClient,
-  @Value("\${clientApi.timeout}") val timeout: Long
-) : ErrorHandlingClient(prisonRegisterWebClient, timeout) {
+  @Value("\${prisonRegister.endpoint.url}") val prisonRegisterEndpointUrl: String,
+  @Value("\${clientApi.timeout}") val timeout: Long,
+  @Autowired private val meterRegistry: MeterRegistry,
+) : ErrorHandlingClient(prisonRegisterWebClient, prisonRegisterEndpointUrl, timeout, meterRegistry) {
 
   fun getAllPrisons(): Mono<List<Api.Prison>> =
     getResponse("/prisons", object : ParameterizedTypeReference<List<Api.Prison>>() {})

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/ClamAVHealthTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/health/ClamAVHealthTest.kt
@@ -4,6 +4,7 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Tags
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -33,6 +34,7 @@ class ClamAVHealthTest {
     assertThat(response.status, equalTo(Status.UP))
 
     verify { clamavClient.ping() }
+    verify { meterRegistry.gauge("upstream_healthcheck", Tags.of("service", "clamAV"), 1) }
   }
 
   @Test
@@ -60,5 +62,6 @@ class ClamAVHealthTest {
     assertThat(response.status, equalTo(Status.DOWN))
 
     verify { clamavClient.ping() }
+    verify { meterRegistry.gauge("upstream_healthcheck", Tags.of("service", "clamAV"), 0) }
   }
 }


### PR DESCRIPTION
This adds prometheus metrics for timeouts calling upstream services.