### PR TITLE
PUD-1524: Ignore ClientTimeoutException's in Sentry

### DIFF
--- a/helm_deploy/manage-recalls-api/values.yaml
+++ b/helm_deploy/manage-recalls-api/values.yaml
@@ -33,7 +33,7 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     GOTENBERG_ENDPOINT_URL: http://manage-recalls-api-gotenberg
-    SENTRY_IGNORED_EXCEPTIONS_FOR_TYPE: uk.gov.justice.digital.hmpps.managerecallsapi.service.VirusFoundException,org.springframework.security.web.firewall.RequestRejectedException,org.springframework.web.HttpMediaTypeNotAcceptableException
+    SENTRY_IGNORED_EXCEPTIONS_FOR_TYPE: uk.gov.justice.digital.hmpps.managerecallsapi.service.VirusFoundException,org.springframework.security.web.firewall.RequestRejectedException,org.springframework.web.HttpMediaTypeNotAcceptableException,uk.gov.justice.digital.hmpps.managerecallsapi.config.ClientTimeoutException
     CLAMAV_HOSTNAME: manage-recalls-api-clamav
     CLAMAV_PORT: 3310
 


### PR DESCRIPTION
We've now got them tracked on the dashboard...