### PR TITLE
Add in a `SentryBeforeSendCallback` class

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/WebConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/config/WebConfig.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.managerecallsapi.config
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
-import uk.gov.justice.digital.hmpps.managerecallsapi.controller.SentryContextAppender
 
 @Configuration
 class WebConfig : WebMvcConfigurer {


### PR DESCRIPTION
This will give us a bit more control of how we react to exceptions (over
the environment variable list of exception classes to ignore). It
doesn't look like the `ClientTimeoutException` catch in the environment
variable is being honoured by Sentry, so fingers crossed this will catch
it...