### PR TITLE
PUD-1578 API person search to return 404 if no results, rather than 500

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/search/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/search/PrisonApiClient.kt
@@ -18,7 +18,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.concurrent.TimeoutException
 
-// FIXME: PUD-1577 - Add some tests to this code
+// FIXME: PUD-1577 - Add some tests to this code - or refactor to greater sharing of webclient handling e.g. with ErrorHandlingClient?
 
 @Component
 class PrisonApiClient(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/SearchComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/SearchComponentTest.kt
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.GATEWAY_TIMEOUT
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNAUTHORIZED
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.SearchController
@@ -18,24 +19,23 @@ class SearchComponentTest : ComponentTestBase() {
 
   private val nomsNumber = NomsNumber("123456")
 
-  // TODO PUD-1578
-  // @Test
-  // fun `returns 404 if get prisoner returns not found`() {
-  //   prisonerOffenderSearchMockServer.getPrisonerByNomsNumberReturnsWith(nomsNumber, NOT_FOUND)
-  //
-  //   val result = authenticatedClient.get("/prisoner/$nomsNumber", NOT_FOUND)
-  //     .expectBody(ErrorResponse::class.java).returnResult().responseBody!!
-  //
-  //   assertThat(
-  //     result,
-  //     equalTo(
-  //       ErrorResponse(
-  //         NOT_FOUND,
-  //         "ClientException: PrisonerOffenderSearchClient: [401 Unauthorized from GET http://localhost:9092/prisoner/123456]"
-  //       )
-  //     )
-  //   )
-  // }
+  @Test
+  fun `returns 404 if get prisoner returns not found`() {
+    prisonerOffenderSearchMockServer.getPrisonerByNomsNumberReturnsWith(nomsNumber, NOT_FOUND)
+
+    val result = authenticatedClient.get("/prisoner/$nomsNumber", NOT_FOUND)
+      .expectBody(ErrorResponse::class.java).returnResult().responseBody!!
+
+    assertThat(
+      result,
+      equalTo(
+        ErrorResponse(
+          NOT_FOUND,
+          "PrisonerNotFoundException(nomsNumber=123456)"
+        )
+      )
+    )
+  }
 
   @Test
   fun `returns 500 if get prisoner returns unauthorized`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/SearchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/SearchControllerTest.kt
@@ -22,14 +22,14 @@ class SearchControllerTest {
   private val nomsNumber = NomsNumber("A1234AA")
 
   @Test
-  fun `prisonerSearch returns prisoner results`() {
+  fun `prisonerByNomsNumber returns prisoner result`() {
     val prisoner1 = prisoner("A1234AA", "Jim", "Smith", "Norman", LocalDate.of(1994, 10, 15))
     every { prisonerOffenderSearchClient.prisonerByNomsNumber(nomsNumber) } returns Mono.just(prisoner1)
 
-    val results = underTest.prisonerByNomsNumber(nomsNumber)
+    val result = underTest.prisonerByNomsNumber(nomsNumber)
 
     StepVerifier
-      .create(results)
+      .create(result)
       .assertNext {
         assertThat(
           it,


### PR DESCRIPTION
Along with PUD-1577, I'm wondering, whether we should move to greater shared code for webClient interaction also considering our current separation of `ErrorHandlingClient` and `AuthenticatingRestClient`. 