### PR TITLE
Fix the owasp dependency check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,6 +466,7 @@ workflows:
             - hmpps-common-vars
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
       - hmpps/gradle_owasp_dependency_check:
+          cache_key: v2_1
           context:
             - hmpps-common-vars
           slack_channel: << pipeline.parameters.alerts-slack-channel >>


### PR DESCRIPTION
ref: https://mojdt.slack.com/archives/C69NWE339/p1646998111225519

It looks like there is a gradle caching issue since updating the HMPPS
gradle-spring-boot-plugin on this task.  This should get it working
again.