### PR TITLE
PUD-1366 Remove un-used alternate end-points from Back End

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressController.kt
@@ -46,15 +46,13 @@ class LastKnownAddressController(
     )
   )
   @PostMapping(
-    "/recalls/{recallId}/last-known-addresses",
-    "/last-known-addresses" // FIXME PUD-1364
+    "/recalls/{recallId}/last-known-addresses"
   )
   fun createLastKnownAddress( // TODO: PUD-1500: should be moved into a service class and annotated @Transactional
-    @PathVariable("recallId") pathRecallId: RecallId?,
+    @PathVariable("recallId") recallId: RecallId,
     @RequestBody request: CreateLastKnownAddressRequest,
     @RequestHeader("Authorization") bearerToken: String
   ): ResponseEntity<LastKnownAddressId> {
-    val recallId = pathRecallId ?: request.recallId!!
     return recallRepository.getByRecallId(recallId).let { recall ->
       val currentUserId = tokenExtractor.getTokenFromHeader(bearerToken).userUuid()
       val previousIndex = recall.lastKnownAddresses.maxByOrNull { it.index }?.index ?: 0
@@ -88,7 +86,6 @@ class LastKnownAddressController(
 }
 
 data class CreateLastKnownAddressRequest(
-  val recallId: RecallId?,
   val line1: String,
   val line2: String?,
   val town: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
@@ -50,15 +50,13 @@ class MissingDocumentsRecordController(
     )
   )
   @PostMapping(
-    "/recalls/{recallId}//missing-documents-records",
-    "/missing-documents-records" // FIXME PUD-1364
+    "/recalls/{recallId}/missing-documents-records"
   )
   fun createMissingDocumentsRecord(
-    @PathVariable("recallId") pathRecallId: RecallId?,
+    @PathVariable("recallId") recallId: RecallId,
     @RequestBody missingDocumentsRecordRequest: MissingDocumentsRecordRequest,
     @RequestHeader("Authorization") bearerToken: String
   ): ResponseEntity<MissingDocumentsRecordId> {
-    val recallId = pathRecallId ?: missingDocumentsRecordRequest.recallId!!
     return recallRepository.getByRecallId(recallId).let { // TODO: PUD-1500: should be moved into a service class and annotated @Transactional
       val currentUserId = tokenExtractor.getTokenFromHeader(bearerToken).userUuid()
       documentService.scanAndStoreDocument(
@@ -92,7 +90,6 @@ class MissingDocumentsRecordController(
 }
 
 data class MissingDocumentsRecordRequest(
-  val recallId: RecallId?,
   val categories: List<DocumentCategory>,
   val details: String,
   val emailFileContent: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AuthenticatedClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/AuthenticatedClient.kt
@@ -210,27 +210,12 @@ class AuthenticatedClient(
       .responseBody!!
 
   fun <T> missingDocumentsRecord(
-    request: MissingDocumentsRecordRequest,
-    expectedStatus: HttpStatus = CREATED,
-    responseClass: Class<T>
-  ) =
-    postRequest("/missing-documents-records", request, responseClass, expectedStatus)
-
-  fun <T> missingDocumentsRecord(
     recallId: RecallId,
     request: MissingDocumentsRecordRequest,
     expectedStatus: HttpStatus = CREATED,
     responseClass: Class<T>
   ) =
     postRequest("/recalls/$recallId/missing-documents-records", request, responseClass, expectedStatus)
-
-  // FIXME PUD-1364
-  fun <T> addLastKnownAddress(
-    request: CreateLastKnownAddressRequest,
-    expectedStatus: HttpStatus = CREATED,
-    responseClass: Class<T>
-  ) =
-    postRequest("/last-known-addresses", request, responseClass, expectedStatus)
 
   fun <T> addLastKnownAddress(
     recallId: RecallId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/EndpointSecurityComponentTest.kt
@@ -35,7 +35,6 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastKnownAddressId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.PhoneNumber
-import uk.gov.justice.digital.hmpps.managerecallsapi.domain.RecallId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.UserId
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.random
 import java.time.LocalDate
@@ -70,9 +69,20 @@ class EndpointSecurityComponentTest : ComponentTestBase() {
   )
   private val updateDocumentRequest = UpdateDocumentRequest(DocumentCategory.values().random())
   private val generateDocumentRequest = GenerateDocumentRequest(DocumentCategory.RECALL_NOTIFICATION, FileName("RECALL_NOTIFICATION.pdf"), "some more detail")
-  private val missingDocumentsRecordRequest = MissingDocumentsRecordRequest(::RecallId.random(), listOf(DocumentCategory.values().random()), "some detail", "content", FileName("email.msg"))
+  private val missingDocumentsRecordRequest = MissingDocumentsRecordRequest(
+    listOf(DocumentCategory.values().random()),
+    "some detail",
+    "content",
+    FileName("email.msg")
+  )
   private val partBRecordRequest = PartBRecordRequest("some detail", LocalDate.now(), FileName("partB.pdf"), "part B content", FileName("email.msg"), "email content", FileName("oasys.pdf"), "oasys content")
-  private val createLastKnownAddressRequest = CreateLastKnownAddressRequest(::RecallId.random(), "address line 1", "address line 2", "some town", "some postcode", AddressSource.LOOKUP)
+  private val createLastKnownAddressRequest = CreateLastKnownAddressRequest(
+    "address line 1",
+    "address line 2",
+    "some town",
+    "some postcode",
+    AddressSource.LOOKUP
+  )
   private val rescindRequestRequest = RescindRequestRequest("details", LocalDate.now(), "some content", FileName("filename"))
   private val rescindDecisionRequest = RescindDecisionRequest(true, "details", LocalDate.now(), "some content", FileName("filename"))
   private val returnedToCustodyRequest = ReturnedToCustodyRequest(OffsetDateTime.now().minusDays(1), OffsetDateTime.now().minusMinutes(1))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallNotificationComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/GetRecallNotificationComponentTest.kt
@@ -57,7 +57,7 @@ class GetRecallNotificationComponentTest : ComponentTestBase() {
     )
     updateRecallWithRequiredInformationForTheRecallNotification(recall.recallId, userId, true, FIXED)
     authenticatedClient.addLastKnownAddress(
-      recall.recallId, CreateLastKnownAddressRequest(null, "1 The Road", null, "A Town", "AB12 3CD", AddressSource.MANUAL),
+      recall.recallId, CreateLastKnownAddressRequest("1 The Road", null, "A Town", "AB12 3CD", AddressSource.MANUAL),
       HttpStatus.CREATED, LastKnownAddressId::class.java
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/LastKnownAddressComponentTest.kt
@@ -35,7 +35,6 @@ class LastKnownAddressComponentTest : ComponentTestBase() {
   fun `create and retrieve one LastKnownAddress for a recall`() {
     val originalRecall = authenticatedClient.bookRecall(bookRecallRequest)
     val createLastKnownAddressRequest = CreateLastKnownAddressRequest(
-      originalRecall.recallId,
       "address line 1",
       "some line 2",
       "some town",
@@ -43,10 +42,11 @@ class LastKnownAddressComponentTest : ComponentTestBase() {
       AddressSource.MANUAL
     )
 
-    val lastKnownAddressId = authenticatedClient.addLastKnownAddress(createLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
+    val recallId = originalRecall.recallId
+    val lastKnownAddressId = authenticatedClient.addLastKnownAddress(recallId, createLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
     assertThat(lastKnownAddressId, present())
 
-    val updatedRecall = authenticatedClient.getRecall(originalRecall.recallId)
+    val updatedRecall = authenticatedClient.getRecall(recallId)
     assertThat(originalRecall.lastKnownAddresses, isEmpty)
 
     val lastKnownAddresses = updatedRecall.lastKnownAddresses
@@ -64,7 +64,6 @@ class LastKnownAddressComponentTest : ComponentTestBase() {
   fun `adding 2 LastKnownAddresses for the same recall, optional properties can be null, both will be returned on the recall with incrementing index`() {
     val originalRecall = authenticatedClient.bookRecall(bookRecallRequest)
     val firstLastKnownAddressRequest = CreateLastKnownAddressRequest(
-      originalRecall.recallId,
       "address line 1",
       "some line 2",
       "first town",
@@ -72,23 +71,23 @@ class LastKnownAddressComponentTest : ComponentTestBase() {
       AddressSource.LOOKUP
     )
 
-    val lastKnownAddressId1 = authenticatedClient.addLastKnownAddress(firstLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
+    val recallId = originalRecall.recallId
+    val lastKnownAddressId1 = authenticatedClient.addLastKnownAddress(recallId, firstLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
     assertThat(lastKnownAddressId1, present())
 
     val secondLastKnownAddressRequest = firstLastKnownAddressRequest.copy(
-      recallId = null,
       line2 = null,
       town = "second town",
       postcode = null,
       source = AddressSource.MANUAL
     )
-    val lastKnownAddressId2 = authenticatedClient.addLastKnownAddress(originalRecall.recallId, secondLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
+    val lastKnownAddressId2 = authenticatedClient.addLastKnownAddress(recallId, secondLastKnownAddressRequest, CREATED, LastKnownAddressId::class.java)
     assertThat(lastKnownAddressId2, present())
     assertThat(lastKnownAddressId1, !equalTo(lastKnownAddressId2))
 
     assertThat(originalRecall.lastKnownAddresses, isEmpty)
 
-    val updatedRecall = authenticatedClient.getRecall(originalRecall.recallId)
+    val updatedRecall = authenticatedClient.getRecall(recallId)
     val lastKnownAddresses = updatedRecall.lastKnownAddresses
     assertThat(lastKnownAddresses.size, equalTo(2))
 
@@ -110,7 +109,6 @@ class LastKnownAddressComponentTest : ComponentTestBase() {
   fun `add a LastKnownAddress with an incorrect recallId returns NOT_FOUND with message`() {
     val notFoundRecallId = ::RecallId.random()
     val createLastKnownAddressRequest = CreateLastKnownAddressRequest(
-      null,
       "address line 1",
       "some line 2",
       "some town",
@@ -129,7 +127,6 @@ class LastKnownAddressComponentTest : ComponentTestBase() {
   fun `can delete a LastKnownAddress`() {
     val originalRecall = authenticatedClient.bookRecall(bookRecallRequest)
     val firstLastKnownAddressRequest = CreateLastKnownAddressRequest(
-      null,
       "address line 1",
       "some line 2",
       "first town",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/MissingDocumentsRecordComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/MissingDocumentsRecordComponentTest.kt
@@ -40,18 +40,18 @@ class MissingDocumentsRecordComponentTest : ComponentTestBase() {
     val recall = authenticatedClient.bookRecall(bookRecallRequest)
     val details = "Some detail"
     val missingDocsRecordReq = MissingDocumentsRecordRequest(
-      recall.recallId,
       listOf(PART_A_RECALL_REPORT),
       details,
       base64EncodedDocumentContents,
       fileName
     )
 
-    val response = authenticatedClient.missingDocumentsRecord(missingDocsRecordReq, CREATED, MissingDocumentsRecordId::class.java)
+    val recallId = recall.recallId
+    val response = authenticatedClient.missingDocumentsRecord(recallId, missingDocsRecordReq, CREATED, MissingDocumentsRecordId::class.java)
 
     assertThat(response, present())
 
-    val recallWithMissingDocumentsRecord = authenticatedClient.getRecall(recall.recallId)
+    val recallWithMissingDocumentsRecord = authenticatedClient.getRecall(recallId)
     assertThat(recall.missingDocumentsRecords, isEmpty)
     assertThat(recallWithMissingDocumentsRecord.missingDocumentsRecords.size, equalTo(1))
     assertThat(recallWithMissingDocumentsRecord.missingDocumentsRecords.first().version, equalTo(1))
@@ -65,20 +65,20 @@ class MissingDocumentsRecordComponentTest : ComponentTestBase() {
     val recall = authenticatedClient.bookRecall(bookRecallRequest)
     val detailsOldest = "Some detail"
     val missingDocsRecordReq = MissingDocumentsRecordRequest(
-      recall.recallId,
       listOf(PART_A_RECALL_REPORT),
       detailsOldest,
       base64EncodedDocumentContents,
       fileName
     )
 
-    authenticatedClient.missingDocumentsRecord(missingDocsRecordReq, CREATED, MissingDocumentsRecordId::class.java)
+    val recallId = recall.recallId
+    authenticatedClient.missingDocumentsRecord(recallId, missingDocsRecordReq, CREATED, MissingDocumentsRecordId::class.java)
     val detailsMostRecent = "Some details; some more detail"
-    val response = authenticatedClient.missingDocumentsRecord(recall.recallId, missingDocsRecordReq.copy(recallId = null, details = detailsMostRecent), CREATED, MissingDocumentsRecordId::class.java)
+    val response = authenticatedClient.missingDocumentsRecord(recallId, missingDocsRecordReq.copy(details = detailsMostRecent), CREATED, MissingDocumentsRecordId::class.java)
 
     assertThat(response, present())
 
-    val recallWithMissingDocumentsRecord = authenticatedClient.getRecall(recall.recallId)
+    val recallWithMissingDocumentsRecord = authenticatedClient.getRecall(recallId)
     assertThat(recall.missingDocumentsRecords, isEmpty)
     val missingDocumentsRecords = recallWithMissingDocumentsRecord.missingDocumentsRecords
     assertThat(missingDocumentsRecords.size, equalTo(2))
@@ -93,7 +93,12 @@ class MissingDocumentsRecordComponentTest : ComponentTestBase() {
     expectAVirusWillBeFound()
 
     val recall = authenticatedClient.bookRecall(bookRecallRequest)
-    val missingDocsRecordReq = MissingDocumentsRecordRequest(null, listOf(PART_A_RECALL_REPORT), "Some detail", base64EncodedDocumentContents, fileName)
+    val missingDocsRecordReq = MissingDocumentsRecordRequest(
+      listOf(PART_A_RECALL_REPORT),
+      "Some detail",
+      base64EncodedDocumentContents,
+      fileName
+    )
 
     val response = authenticatedClient.missingDocumentsRecord(recall.recallId, missingDocsRecordReq, BAD_REQUEST, ErrorResponse::class.java)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressControllerTest.kt
@@ -59,7 +59,7 @@ class LastKnownAddressControllerTest {
     every { lastKnownAddress.id() } returns lastKnownAddressId
 
     val request = CreateLastKnownAddressRequest(
-      null, line1, line2, town, postcode, source
+      line1, line2, town, postcode, source
     )
 
     val response = underTest.createLastKnownAddress(recallId, request, bearerToken)
@@ -106,10 +106,10 @@ class LastKnownAddressControllerTest {
     every { address.id() } returns lastKnownAddressId
 
     val request = CreateLastKnownAddressRequest(
-      recallId, line1, line2, town, postcode, source
+      line1, line2, town, postcode, source
     )
 
-    val response = underTest.createLastKnownAddress(null, request, bearerToken)
+    val response = underTest.createLastKnownAddress(recallId, request, bearerToken)
 
     assertThat(savedLastKnownAddress.captured.index, equalTo(previousMaxIndex + 1))
     assertThat(savedLastKnownAddress.captured.line1, equalTo(line1))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
@@ -68,11 +68,11 @@ class MissingDocumentsRecordControllerTest {
     every { record.id() } returns missingDocumentsRecordId
 
     val request = MissingDocumentsRecordRequest(
-      recallId, listOf(DocumentCategory.PART_A_RECALL_REPORT), details,
-      documentBytes.encodeToBase64String(), fileName
+      listOf(DocumentCategory.PART_A_RECALL_REPORT), details, documentBytes.encodeToBase64String(),
+      fileName
     )
 
-    val response = underTest.createMissingDocumentsRecord(null, request, bearerToken)
+    val response = underTest.createMissingDocumentsRecord(recallId, request, bearerToken)
 
     assertThat(savedMissingDocumentsRecord.captured.version, equalTo(1))
     assertThat(savedMissingDocumentsRecord.captured.details, equalTo(details))
@@ -117,8 +117,8 @@ class MissingDocumentsRecordControllerTest {
     every { record.id() } returns missingDocumentsRecordId
 
     val request = MissingDocumentsRecordRequest(
-      null, listOf(DocumentCategory.PART_A_RECALL_REPORT), details,
-      documentBytes.encodeToBase64String(), fileName
+      listOf(DocumentCategory.PART_A_RECALL_REPORT), details, documentBytes.encodeToBase64String(),
+      fileName
     )
 
     val response = underTest.createMissingDocumentsRecord(recallId, request, bearerToken)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/RecallNotificationGotenbergComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/integration/documents/RecallNotificationGotenbergComponentTest.kt
@@ -102,7 +102,7 @@ class RecallNotificationGotenbergComponentTest : GotenbergComponentTestBase() {
       recallType = RecallType.FIXED,
     )
     authenticatedClient.addLastKnownAddress(
-      recall.recallId, CreateLastKnownAddressRequest(null, "1 The Road", null, "A Town", "AB12 3CD", AddressSource.MANUAL),
+      recall.recallId, CreateLastKnownAddressRequest("1 The Road", null, "A Town", "AB12 3CD", AddressSource.MANUAL),
       HttpStatus.CREATED, LastKnownAddressId::class.java
     )
 


### PR DESCRIPTION
PUD-1366 Remove un-used alternate end-points from Back End, i.e. removal of old end-points for /missing-documents-records and /last-known-addresses