### PR TITLE
PUD-1679 Slice 1 of remove <ResponseEntity<T>> return types

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/DocumentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/DocumentController.kt
@@ -75,20 +75,18 @@ class DocumentController(
   fun getRecallDocument(
     @PathVariable("recallId") recallId: RecallId,
     @PathVariable("documentId") documentId: DocumentId
-  ): ResponseEntity<GetDocumentResponse> {
+  ): GetDocumentResponse {
     val (document, bytes) = documentService.getDocument(recallId, documentId)
 
-    return ResponseEntity.ok(
-      GetDocumentResponse(
-        documentId,
-        document.category,
-        bytes.encodeToBase64String(),
-        document.fileName,
-        document.version,
-        document.details,
-        userDetailsService.get(document.createdByUserId()).fullName(),
-        document.createdDateTime
-      )
+    return GetDocumentResponse(
+      documentId,
+      document.category,
+      bytes.encodeToBase64String(),
+      document.fileName,
+      document.version,
+      document.details,
+      userDetailsService.get(document.createdByUserId()).fullName(),
+      document.createdDateTime
     )
   }
 
@@ -96,21 +94,18 @@ class DocumentController(
   fun getRecallDocumentsByCategory(
     @PathVariable("recallId") recallId: RecallId,
     @RequestParam("category") category: DocumentCategory
-  ): ResponseEntity<List<Api.RecallDocument>> {
-    return ResponseEntity.ok(
-      documentService.getAllDocumentsByCategory(recallId, category).map { document ->
-        Api.RecallDocument(
-          document.id(),
-          document.category,
-          document.fileName,
-          document.version,
-          document.details,
-          document.createdDateTime,
-          userDetailsService.get(document.createdByUserId()).fullName()
-        )
-      }
-    )
-  }
+  ): List<Api.RecallDocument> =
+    documentService.getAllDocumentsByCategory(recallId, category).map { document ->
+      Api.RecallDocument(
+        document.id(),
+        document.category,
+        document.fileName,
+        document.version,
+        document.details,
+        document.createdDateTime,
+        userDetailsService.get(document.createdByUserId()).fullName()
+      )
+    }
 
   @ApiResponses(
     ApiResponse(
@@ -199,16 +194,14 @@ class DocumentController(
     @PathVariable("recallId") recallId: RecallId,
     @PathVariable("documentId") documentId: DocumentId,
     @RequestBody updateDocumentRequest: UpdateDocumentRequest
-  ): ResponseEntity<UpdateDocumentResponse> {
+  ): UpdateDocumentResponse {
     val document = documentService.updateDocumentCategory(recallId, documentId, updateDocumentRequest.category)
-    return ResponseEntity.ok(
-      UpdateDocumentResponse(
-        document.id(),
-        document.recallId(),
-        document.category,
-        document.fileName,
-        document.details
-      )
+    return UpdateDocumentResponse(
+      document.id(),
+      document.recallId(),
+      document.category,
+      document.fileName,
+      document.details
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressController.kt
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -48,11 +47,12 @@ class LastKnownAddressController(
   @PostMapping(
     "/recalls/{recallId}/last-known-addresses"
   )
+  @ResponseStatus(HttpStatus.CREATED)
   fun createLastKnownAddress( // TODO: PUD-1500: should be moved into a service class and annotated @Transactional
     @PathVariable("recallId") recallId: RecallId,
     @RequestBody request: CreateLastKnownAddressRequest,
     @RequestHeader("Authorization") bearerToken: String
-  ): ResponseEntity<LastKnownAddressId> {
+  ): LastKnownAddressId {
     return recallRepository.getByRecallId(recallId).let { recall ->
       val currentUserId = tokenExtractor.getTokenFromHeader(bearerToken).userUuid()
       val previousIndex = recall.lastKnownAddresses.maxByOrNull { it.index }?.index ?: 0
@@ -70,7 +70,7 @@ class LastKnownAddressController(
           OffsetDateTime.now()
         )
       )
-      ResponseEntity(saved.id(), HttpStatus.CREATED)
+      saved.id()
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordController.kt
@@ -9,13 +9,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.VirusFoundException
@@ -52,11 +52,12 @@ class MissingDocumentsRecordController(
   @PostMapping(
     "/recalls/{recallId}/missing-documents-records"
   )
+  @ResponseStatus(HttpStatus.CREATED)
   fun createMissingDocumentsRecord(
     @PathVariable("recallId") recallId: RecallId,
     @RequestBody missingDocumentsRecordRequest: MissingDocumentsRecordRequest,
     @RequestHeader("Authorization") bearerToken: String
-  ): ResponseEntity<MissingDocumentsRecordId> {
+  ): MissingDocumentsRecordId {
     return recallRepository.getByRecallId(recallId).let { // TODO: PUD-1500: should be moved into a service class and annotated @Transactional
       val currentUserId = tokenExtractor.getTokenFromHeader(bearerToken).userUuid()
       documentService.scanAndStoreDocument(
@@ -80,8 +81,7 @@ class MissingDocumentsRecordController(
             OffsetDateTime.now()
           )
         )
-
-        ResponseEntity(mdr.id(), HttpStatus.CREATED)
+        mdr.id()
       }.onFailure {
         throw VirusFoundException()
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RescindRecordController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RescindRecordController.kt
@@ -5,7 +5,6 @@ import dev.forkhandles.result4k.onFailure
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -13,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.VirusFoundException
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.extractor.TokenExtractor
@@ -31,14 +31,15 @@ class RescindRecordController(
 ) {
 
   @PostMapping("/recalls/{recallId}/rescind-records")
+  @ResponseStatus(HttpStatus.CREATED)
   fun createRescindRecord(
     @PathVariable("recallId") recallId: RecallId,
     @RequestBody request: RescindRequestRequest,
     @RequestHeader("Authorization") bearerToken: String
-  ): ResponseEntity<RescindRecordId> =
+  ): RescindRecordId =
     tokenExtractor.getTokenFromHeader(bearerToken).userUuid().let { currentUserId ->
       rescindRecordService.createRecord(recallId, currentUserId, request).map {
-        ResponseEntity(it, HttpStatus.CREATED)
+        it
       }.onFailure {
         throw VirusFoundException()
       }
@@ -50,10 +51,10 @@ class RescindRecordController(
     @PathVariable("rescindRecordId") rescindRecordId: RescindRecordId,
     @RequestBody request: RescindDecisionRequest,
     @RequestHeader("Authorization") bearerToken: String
-  ): ResponseEntity<RescindRecordId> =
+  ): RescindRecordId =
     tokenExtractor.getTokenFromHeader(bearerToken).userUuid().let { currentUserId ->
       rescindRecordService.makeDecision(recallId, currentUserId, rescindRecordId, request).map {
-        ResponseEntity.ok(it)
+        it
       }.onFailure {
         throw VirusFoundException()
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/DocumentComponentTest.kt
@@ -331,7 +331,7 @@ class DocumentComponentTest : ComponentTestBase() {
   }
 
   // TODO: there are no documents generated prior to `Assess Recall` - so why this test "for Recall being booked"?
-  //  - PS: Answer: for completion since we verify we cant delete an uploaded doc during 'being booked'
+  //  - PS: Answer: for completion since we verify we can not delete an uploaded doc during 'being booked'
   @Test
   fun `can't delete generated document for Recall being booked`() {
     expectNoVirusesWillBeFound()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/NoteComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/NoteComponentTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.managerecallsapi.domain.CroNumber
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.FirstName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.LastName
 import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NomsNumber
+import uk.gov.justice.digital.hmpps.managerecallsapi.domain.NoteId
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomFileName
 import uk.gov.justice.digital.hmpps.managerecallsapi.random.randomString
 import java.time.LocalDate
@@ -47,7 +48,8 @@ class NoteComponentTest : ComponentTestBase() {
 
     assertThat(recall.notes, isEmpty)
 
-    val noteId = authenticatedClient.createNote(recall.recallId, createRequest)
+    val noteId = authenticatedClient.addNote(recall.recallId, createRequest, HttpStatus.CREATED, NoteId::class.java)
+
     val recallWithNote = authenticatedClient.getRecall(recall.recallId)
 
     assertThat(recallWithNote.notes.size, equalTo(1))
@@ -72,8 +74,7 @@ class NoteComponentTest : ComponentTestBase() {
       base64EncodedDocumentContents,
     )
 
-    val result = authenticatedClient.createNote(recall.recallId, createRequest, HttpStatus.BAD_REQUEST)
-      .expectBody(ErrorResponse::class.java).returnResult().responseBody!!
+    val result = authenticatedClient.addNote(recall.recallId, createRequest, HttpStatus.BAD_REQUEST, ErrorResponse::class.java)
 
     assertThat(result, equalTo(ErrorResponse(HttpStatus.BAD_REQUEST, "VirusFoundException")))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/RescindRecordComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/RescindRecordComponentTest.kt
@@ -7,8 +7,13 @@ import com.natpryce.hamkrest.isEmpty
 import com.natpryce.hamkrest.present
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.managerecallsapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.BookRecallRequest
+import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RecallResponse
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RescindRecordController
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RescindRecordController.RescindRequestRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.Status
@@ -61,7 +66,7 @@ class RescindRecordComponentTest : ComponentTestBase() {
 
     assertThat(recall.rescindRecords, isEmpty)
 
-    val rescindRecordId = authenticatedClient.requestRescind(recall.recallId, createRequest)
+    val rescindRecordId = requestRescindSuccess(recall, createRequest)
     val recallWithRequestedRescindRecord = authenticatedClient.getRecall(recall.recallId)
 
     assertThat(recallWithRequestedRescindRecord.rescindRecords.size, equalTo(1))
@@ -80,7 +85,7 @@ class RescindRecordComponentTest : ComponentTestBase() {
     assertThat(recallWithRequestedRescindRecord.stopByUserName, absent())
     assertThat(recallWithRequestedRescindRecord.stopDateTime, absent())
 
-    authenticatedClient.decideRescind(recall.recallId, rescindRecordId, decisionRequest)
+    decideRescindSuccess(recall, rescindRecordId, decisionRequest)
     val recallWithApprovedRescindRecord = authenticatedClient.getRecall(recall.recallId)
 
     assertThat(recallWithApprovedRescindRecord.status, equalTo(Status.STOPPED))
@@ -123,7 +128,7 @@ class RescindRecordComponentTest : ComponentTestBase() {
 
     assertThat(recall.rescindRecords, isEmpty)
 
-    val rescindRecordId = authenticatedClient.requestRescind(recall.recallId, createRequest)
+    val rescindRecordId = requestRescindSuccess(recall, createRequest)
     val recallWithRequestedRescindRecord = authenticatedClient.getRecall(recall.recallId)
 
     assertThat(recallWithRequestedRescindRecord.rescindRecords.size, equalTo(1))
@@ -132,7 +137,7 @@ class RescindRecordComponentTest : ComponentTestBase() {
     assertThat(recallWithRequestedRescindRecord.stopByUserName, absent())
     assertThat(recallWithRequestedRescindRecord.stopDateTime, absent())
 
-    authenticatedClient.decideRescind(recall.recallId, rescindRecordId, decisionRequest)
+    decideRescindSuccess(recall, rescindRecordId, decisionRequest)
     val recallWithApprovedRescindRecord = authenticatedClient.getRecall(recall.recallId)
 
     assertThat(recallWithApprovedRescindRecord.status, equalTo(Status.BEING_BOOKED_ON))
@@ -148,7 +153,7 @@ class RescindRecordComponentTest : ComponentTestBase() {
     expectNoVirusesWillBeFound()
     val recall = authenticatedClient.bookRecall(bookRecallRequest)
 
-    val putRequest = RescindRecordController.RescindDecisionRequest(
+    val decisionRequest = RescindRecordController.RescindDecisionRequest(
       true,
       "Some details",
       LocalDate.now(),
@@ -156,7 +161,7 @@ class RescindRecordComponentTest : ComponentTestBase() {
       approvalFileName
     )
 
-    authenticatedClient.decideRescind(recall.recallId, ::RescindRecordId.random(), putRequest, HttpStatus.NOT_FOUND)
+    decideRescindFailure(recall, ::RescindRecordId.random(), decisionRequest, NOT_FOUND)
   }
 
   @Test
@@ -173,8 +178,7 @@ class RescindRecordComponentTest : ComponentTestBase() {
       requestFileName
     )
 
-    val result = authenticatedClient.requestRescind(recall.recallId, createRequest, HttpStatus.BAD_REQUEST)
-      .expectBody(ErrorResponse::class.java).returnResult().responseBody!!
+    val result = requestRescindFailure(recall, createRequest, HttpStatus.BAD_REQUEST)
 
     assertThat(result, equalTo(ErrorResponse(HttpStatus.BAD_REQUEST, "VirusFoundException")))
   }
@@ -191,12 +195,12 @@ class RescindRecordComponentTest : ComponentTestBase() {
       base64EncodedDocumentContents,
       requestFileName
     )
-    authenticatedClient.requestRescind(recall.recallId, createRequest)
-    authenticatedClient.requestRescind(recall.recallId, createRequest, HttpStatus.FORBIDDEN)
+    requestRescindSuccess(recall, createRequest)
+    requestRescindFailure(recall, createRequest, FORBIDDEN)
   }
 
   @Test
-  fun `cant update a record which has already been decided`() {
+  fun `can not update a record which has already been decided`() {
     expectNoVirusesWillBeFound()
     val recall = authenticatedClient.bookRecall(bookRecallRequest)
 
@@ -215,9 +219,33 @@ class RescindRecordComponentTest : ComponentTestBase() {
       approvalFileName
     )
 
-    val rescindRecordId = authenticatedClient.requestRescind(recall.recallId, createRequest)
+    val rescindRecordId = requestRescindSuccess(recall, createRequest)
 
-    authenticatedClient.decideRescind(recall.recallId, rescindRecordId, decisionRequest)
-    authenticatedClient.decideRescind(recall.recallId, rescindRecordId, decisionRequest, HttpStatus.FORBIDDEN)
+    decideRescindSuccess(recall, rescindRecordId, decisionRequest)
+    decideRescindFailure(recall, rescindRecordId, decisionRequest, FORBIDDEN)
   }
+
+  private fun requestRescindSuccess(
+    recall: RecallResponse,
+    createRequest: RescindRequestRequest
+  ) = authenticatedClient.requestRescind(recall.recallId, createRequest, CREATED, RescindRecordId::class.java)
+
+  private fun requestRescindFailure(
+    recall: RecallResponse,
+    createRequest: RescindRequestRequest,
+    expectedStatus: HttpStatus
+  ) = authenticatedClient.requestRescind(recall.recallId, createRequest, expectedStatus, ErrorResponse::class.java)
+
+  private fun decideRescindSuccess(
+    recall: RecallResponse,
+    rescindRecordId: RescindRecordId,
+    decisionRequest: RescindRecordController.RescindDecisionRequest
+  ) = authenticatedClient.decideRescind(recall.recallId, rescindRecordId, decisionRequest, OK, RescindRecordId::class.java)
+
+  private fun decideRescindFailure(
+    recall: RecallResponse,
+    rescindRecordId: RescindRecordId,
+    decisionRequest: RescindRecordController.RescindDecisionRequest,
+    status: HttpStatus
+  ) = authenticatedClient.decideRescind(recall.recallId, rescindRecordId, decisionRequest, status, ErrorResponse::class.java)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/RescindRecordComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/component/RescindRecordComponentTest.kt
@@ -161,7 +161,10 @@ class RescindRecordComponentTest : ComponentTestBase() {
       approvalFileName
     )
 
-    decideRescindFailure(recall, ::RescindRecordId.random(), decisionRequest, NOT_FOUND)
+    val rescindRecordId = ::RescindRecordId.random()
+    val result = decideRescindFailure(recall, rescindRecordId, decisionRequest, NOT_FOUND)
+
+    assertThat(result, equalTo(ErrorResponse(NOT_FOUND, "RescindRecordNotFoundException(recallId=${recall.recallId}, rescindRecordId=$rescindRecordId)")))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/DocumentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/DocumentControllerTest.kt
@@ -131,9 +131,8 @@ class DocumentControllerTest {
     every { userDetails.fullName() } returns fullName
     every { documentService.getDocument(recallId1, documentId) } returns Pair(aRecallDocument, bytes)
 
-    val response = underTest.getRecallDocument(recallId1, documentId)
+    val body = underTest.getRecallDocument(recallId1, documentId)
 
-    assertThat(response.statusCode, equalTo(HttpStatus.OK))
     val expected = GetDocumentResponse(
       documentId,
       aRecallDocument.category,
@@ -144,7 +143,7 @@ class DocumentControllerTest {
       fullName,
       now
     )
-    assertThat(response.body, equalTo(expected))
+    assertThat(body, equalTo(expected))
   }
 
   @Test
@@ -171,9 +170,9 @@ class DocumentControllerTest {
     every { userDetailsService.get(createdByUserId) } returns userDetails
     every { userDetails.fullName() } returns FullName("Andy Newton")
 
-    val result = underTest.getRecallDocumentsByCategory(recallId, category)
+    val body = underTest.getRecallDocumentsByCategory(recallId, category)
 
-    assertThat(result.body, equalTo(listOf(Api.RecallDocument(document.id(), category, FileName("file.pdf"), 1, null, now, FullName("Andy Newton")))))
+    assertThat(body, equalTo(listOf(Api.RecallDocument(document.id(), category, FileName("file.pdf"), 1, null, now, FullName("Andy Newton")))))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/LastKnownAddressControllerTest.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.extractor.TokenExtractor
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.AddressSource
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.LastKnownAddress
@@ -62,7 +61,7 @@ class LastKnownAddressControllerTest {
       line1, line2, town, postcode, source
     )
 
-    val response = underTest.createLastKnownAddress(recallId, request, bearerToken)
+    val body = underTest.createLastKnownAddress(recallId, request, bearerToken)
 
     assertThat(savedLastKnownAddress.captured.index, equalTo(1))
     assertThat(UUID.fromString(savedLastKnownAddress.captured.id.toString()), present())
@@ -72,9 +71,9 @@ class LastKnownAddressControllerTest {
     assertThat(savedLastKnownAddress.captured.town, equalTo(town))
     assertThat(savedLastKnownAddress.captured.postcode, equalTo(postcode))
     assertThat(savedLastKnownAddress.captured.source, equalTo(source))
-    assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
+
     assertThat(
-      response.body,
+      body,
       equalTo(
         lastKnownAddressId
       )
@@ -109,7 +108,7 @@ class LastKnownAddressControllerTest {
       line1, line2, town, postcode, source
     )
 
-    val response = underTest.createLastKnownAddress(recallId, request, bearerToken)
+    val body = underTest.createLastKnownAddress(recallId, request, bearerToken)
 
     assertThat(savedLastKnownAddress.captured.index, equalTo(previousMaxIndex + 1))
     assertThat(savedLastKnownAddress.captured.line1, equalTo(line1))
@@ -117,9 +116,9 @@ class LastKnownAddressControllerTest {
     assertThat(savedLastKnownAddress.captured.town, equalTo(town))
     assertThat(savedLastKnownAddress.captured.postcode, equalTo(null))
     assertThat(savedLastKnownAddress.captured.source, equalTo(source))
-    assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
+
     assertThat(
-      response.body,
+      body,
       equalTo(
         lastKnownAddressId
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/MissingDocumentsRecordControllerTest.kt
@@ -7,7 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.extractor.TokenExtractor
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.DocumentCategory
 import uk.gov.justice.digital.hmpps.managerecallsapi.db.MissingDocumentsRecord
@@ -72,13 +71,12 @@ class MissingDocumentsRecordControllerTest {
       fileName
     )
 
-    val response = underTest.createMissingDocumentsRecord(recallId, request, bearerToken)
+    val body = underTest.createMissingDocumentsRecord(recallId, request, bearerToken)
 
     assertThat(savedMissingDocumentsRecord.captured.version, equalTo(1))
     assertThat(savedMissingDocumentsRecord.captured.details, equalTo(details))
-    assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
     assertThat(
-      response.body,
+      body,
       equalTo(
         missingDocumentsRecordId
       )
@@ -121,12 +119,11 @@ class MissingDocumentsRecordControllerTest {
       fileName
     )
 
-    val response = underTest.createMissingDocumentsRecord(recallId, request, bearerToken)
+    val body = underTest.createMissingDocumentsRecord(recallId, request, bearerToken)
 
     assertThat(savedMissingDocumentsRecord.captured.version, equalTo(2))
-    assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
     assertThat(
-      response.body,
+      body,
       equalTo(
         missingDocumentsRecordId
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RescindRecordControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/controller/RescindRecordControllerTest.kt
@@ -6,7 +6,6 @@ import dev.forkhandles.result4k.Success
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RescindRecordController.RescindDecisionRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.RescindRecordController.RescindRequestRequest
 import uk.gov.justice.digital.hmpps.managerecallsapi.controller.extractor.TokenExtractor
@@ -45,10 +44,9 @@ class RescindRecordControllerTest {
     every { tokenExtractor.getTokenFromHeader(bearerToken) } returns TokenExtractor.Token(userId.toString())
     every { rescindRecordService.createRecord(recallId, userId, request) } returns Success(rescindRecordId)
 
-    val response = underTest.createRescindRecord(recallId, request, bearerToken)
+    val body = underTest.createRescindRecord(recallId, request, bearerToken)
 
-    assertThat(response.statusCode, equalTo(HttpStatus.CREATED))
-    assertThat(response.body, equalTo(rescindRecordId))
+    assertThat(body, equalTo(rescindRecordId))
   }
 
   @Test
@@ -63,10 +61,8 @@ class RescindRecordControllerTest {
     every { tokenExtractor.getTokenFromHeader(bearerToken) } returns TokenExtractor.Token(userId.toString())
     every { rescindRecordService.makeDecision(recallId, userId, rescindRecordId, decisionRequest) } returns Success(rescindRecordId)
 
-    val response =
-      underTest.decideRescindRecord(recallId, rescindRecordId, decisionRequest, bearerToken)
+    val body = underTest.decideRescindRecord(recallId, rescindRecordId, decisionRequest, bearerToken)
 
-    assertThat(response.statusCode, equalTo(HttpStatus.OK))
-    assertThat(response.body, equalTo(rescindRecordId))
+    assertThat(body, equalTo(rescindRecordId))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RescindRecordServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managerecallsapi/service/RescindRecordServiceTest.kt
@@ -305,7 +305,7 @@ class RescindRecordServiceTest {
   }
 
   @Test
-  fun `cant update a record which has already been decided`() {
+  fun `can not update a record which has already been decided`() {
     val recall = mockk<Recall>()
     val documentBytes = "a document".toByteArray()
     val fileName = FileName("email.msg")


### PR DESCRIPTION
PUD-1679 Slice 1 of remove <ResponseEntity<T>> return types in Controllers
Code clean-up: let's agree if this is good before doing much more of the same.