### PR TITLE
PUD-1705  API build fails on Kotlin 1.6.20 (hmpps plugin > 4.1.3): compileTestKotlin StackOverflowError!

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,13 +88,15 @@ dependencies {
 }
 
 kotlin {
-  kotlinDaemonJvmArgs = listOf("-Xmx2g", "-Xms=1g", "-XX:ThreadStackSize=4096", "-XX:CompilerThreadStackSize=4096")
+  // Re. PUD-1705 compilation failure: So that JVM params are consistent for local and CircleCI builds this and ./gradle.properties org.gradle.jvmargs setting should match precisely
+  kotlinDaemonJvmArgs = listOf("-Xmx2g", "-XX:ThreadStackSize=4096", "-XX:CompilerThreadStackSize=4096", "-XX:MaxMetaspaceSize=512m", "-XX:+HeapDumpOnOutOfMemoryError", "-Dfile.encoding=UTF-8")
 }
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
       jvmTarget = JavaVersion.VERSION_17.toString()
+      verbose = true
     }
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,10 @@ dependencies {
   testImplementation("io.swagger.parser.v3:swagger-parser:2.0.31")
 }
 
+kotlin {
+  kotlinDaemonJvmArgs = listOf("-Xmx2g", "-Xms=1g", "-XX:ThreadStackSize=4096", "-XX:CompilerThreadStackSize=4096")
+}
+
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,15 +88,16 @@ dependencies {
 }
 
 kotlin {
-  // Re. PUD-1705 compilation failure: So that JVM params are consistent for local and CircleCI builds this and ./gradle.properties org.gradle.jvmargs setting should match precisely
-  kotlinDaemonJvmArgs = listOf("-Xmx2g", "-XX:ThreadStackSize=4096", "-XX:CompilerThreadStackSize=4096", "-XX:MaxMetaspaceSize=512m", "-XX:+HeapDumpOnOutOfMemoryError", "-Dfile.encoding=UTF-8")
+  // Re. PUD-1705 compilation stackoverflowError: for compileTestKotlin to pass on local and CircleCI below and ./gradle.properties org.gradle.jvmargs setting should match
+  // This setting is applied for the local build but ./gradle.properties is not; whereas ./gradle.properties is applied on CircleCI and this setting is not ... at least not successfully.
+  // And when changing these properties the change may be ignored for a local build unless you kill all running gradle daemons between changes with e.g. ./gradlew --stop
+  kotlinDaemonJvmArgs = listOf("-Xmx2g", "-XX:ThreadStackSize=4096", "-XX:CompilerThreadStackSize=4096", "-XX:MaxMetaspaceSize=512m", "-XX:+HeapDumpOnOutOfMemoryError")
 }
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
       jvmTarget = JavaVersion.VERSION_17.toString()
-      verbose = true
     }
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.3"
-  kotlin("plugin.spring") version "1.6.20"
-  kotlin("plugin.jpa") version "1.5.20"
-  kotlin("plugin.serialization") version "1.4.31"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.5"
+  kotlin("plugin.spring") version "1.6.21"
+  kotlin("plugin.jpa") version "1.6.21"
+  kotlin("plugin.serialization") version "1.6.21"
   id("org.owasp.dependencycheck") version "6.5.0.1"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx2g,-Xms=1g,-XX:ThreadStackSize=4096,-XX:CompilerThreadStackSize=4096

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx2g,-Xms=1g,-XX:ThreadStackSize=4096,-XX:CompilerThreadStackSize=4096

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx2g -XX:ThreadStackSize=4096 -XX:CompilerThreadStackSize=4096 -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.daemon=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
+# Needs to match e.g. kotlinDaemonJvmArgs so that JVM config is applied for build processes on CI
 org.gradle.jvmargs=-Xmx2g -XX:ThreadStackSize=4096 -XX:CompilerThreadStackSize=4096 -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+# Needed so that all our build gradlew processes on CI respect the above - and then log e.g. "To honour the JVM settings for this build a single-use Daemon process will be forked...."
+org.gradle.daemon=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-org.gradle.jvmargs=-Xmx2g -XX:ThreadStackSize=4096 -XX:CompilerThreadStackSize=4096 -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.daemon=false
+org.gradle.jvmargs=-Xmx2g -XX:ThreadStackSize=4096 -XX:CompilerThreadStackSize=4096 -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
Found a set of JVM configuration allowing all compile steps to pass - and eventually also how to have them applied successfully for local and all our CI builds.